### PR TITLE
Support Swagger syntax for String-keyed maps.

### DIFF
--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+shapeUtilityFunctions.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+shapeUtilityFunctions.swift
@@ -116,6 +116,9 @@ public extension ServiceModelCodeGenerator {
             case .map(let keyType, let valueType, _):
                 (fieldShape, associatedTypes) = getMapShapeType(keyType: keyType, valueType: valueType)
             }
+        } else if typeName.isBuiltinType {
+            fieldShape = typeName
+            associatedTypes = []
         } else {
             fieldShape = "\(typeName)Type"
             associatedTypes = ["\(typeName)Type: \(typeName)Shape"]


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* Support Swagger syntax for String-keyed maps.

* https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md

For a simple string to string mapping:
```
  MyMap:
    type: "object"
    additionalProperties:
      type: string
```

For a string to model mapping:
```
  MyMap:
    type: "object"
    additionalProperties:
      $ref: "#/definitions/TheValue"
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
