### PR TITLE
Add map case for willShapeConversionFail

### DIFF
--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateConversionFunctions.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateConversionFunctions.swift
@@ -29,13 +29,13 @@ extension ServiceModelCodeGenerator {
         let willConversionFail = willShapeConversionFail(fieldName: innerType, alreadySeenShapes: [])
         
         let tryPrefix: String
-        let failPostix: String
+        let failPostfix: String
         if willConversionFail {
             tryPrefix = "try "
-            failPostix = " throws"
+            failPostfix = " throws"
         } else {
             tryPrefix = ""
-            failPostix = ""
+            failPostfix = ""
         }
         
         let category = getShapeCategory(fieldName: innerType,
@@ -48,7 +48,7 @@ extension ServiceModelCodeGenerator {
             fileBuilder.appendLine("""
             
             public extension Array where Element: \(type) {
-               func as\(baseName)Model\(typeName)()\(failPostix) -> \(baseName)Model.\(typeName) {
+               func as\(baseName)Model\(typeName)()\(failPostfix) -> \(baseName)Model.\(typeName) {
                    return \(tryPrefix)self.map { \(tryPrefix)$0.as\(baseName)Model\(innerTypeName)() }
                }
             }
@@ -57,7 +57,7 @@ extension ServiceModelCodeGenerator {
             fileBuilder.appendLine("""
             
             public extension Array where \(whereClause) {
-               func as\(baseName)Model\(typeName)()\(failPostix) -> \(baseName)Model.\(typeName) {
+               func as\(baseName)Model\(typeName)()\(failPostfix) -> \(baseName)Model.\(typeName) {
                    return \(tryPrefix)self.map { \(tryPrefix)$0.as\(baseName)Model\(innerTypeName)() }
                }
             }
@@ -66,7 +66,7 @@ extension ServiceModelCodeGenerator {
             fileBuilder.appendLine("""
             
             public extension Array where Element: CustomStringConvertible {
-               func as\(baseName)Model\(typeName)()\(failPostix) -> \(baseName)Model.\(typeName) {
+               func as\(baseName)Model\(typeName)()\(failPostfix) -> \(baseName)Model.\(typeName) {
                    return \(tryPrefix)self.map { \(tryPrefix)$0.as\(baseName)Model\(innerTypeName)() }
                }
             }
@@ -82,13 +82,13 @@ extension ServiceModelCodeGenerator {
         let willConversionFail = willShapeConversionFail(fieldName: valueType, alreadySeenShapes: [])
         
         let tryPrefix: String
-        let failPostix: String
+        let failPostfix: String
         if willConversionFail {
             tryPrefix = "try "
-            failPostix = " throws"
+            failPostfix = " throws"
         } else {
             tryPrefix = ""
-            failPostix = ""
+            failPostfix = ""
         }
         
         let category = getShapeCategory(fieldName: valueType,
@@ -101,7 +101,7 @@ extension ServiceModelCodeGenerator {
             fileBuilder.appendLine("""
             
             public extension Dictionary where Key == String, Value: \(type) {
-               func as\(baseName)Model\(typeName)()\(failPostix) -> \(baseName)Model.\(typeName) {
+               func as\(baseName)Model\(typeName)()\(failPostfix) -> \(baseName)Model.\(typeName) {
                    return \(tryPrefix)self.mapValues { \(tryPrefix)$0.as\(baseName)Model\(valueType)() }
                }
             }
@@ -110,7 +110,7 @@ extension ServiceModelCodeGenerator {
             fileBuilder.appendLine("""
             
             public extension Dictionary where Key == String, \(whereClause) {
-               func as\(baseName)Model\(typeName)()\(failPostix) -> \(baseName)Model.\(typeName) {
+               func as\(baseName)Model\(typeName)()\(failPostfix) -> \(baseName)Model.\(typeName) {
                    return \(tryPrefix)self.mapValues { \(tryPrefix)$0.as\(baseName)Model\(valueType)() }
                }
             }
@@ -119,7 +119,7 @@ extension ServiceModelCodeGenerator {
             fileBuilder.appendLine("""
             
             public extension Dictionary where Value: CustomStringConvertible {
-               func as\(baseName)Model\(typeName)()\(failPostix) -> \(baseName)Model.\(typeName) {
+               func as\(baseName)Model\(typeName)()\(failPostfix) -> \(baseName)Model.\(typeName) {
                    return \(tryPrefix)self.mapValues { \(tryPrefix)$0.as\(baseName)Model\(valueType)() }
                }
             }

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+shapeConversion.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+shapeConversion.swift
@@ -109,7 +109,7 @@ internal extension ServiceModelCodeGenerator {
     private func getListShapeToInstanceConversion(fieldName: String, type: String,
                                                   variableName: String, isRequired: Bool) -> (setup: String?, fieldShape: String) {
         let willConversionFail = willShapeConversionFail(fieldName: type, alreadySeenShapes: [])
-        let failPostix = willConversionFail ? "try " : ""
+        let failPostfix = willConversionFail ? "try " : ""
         let optionalInfix = isRequired ? "" : "?"
 
         let typeName = type.getNormalizedTypeName(forModel: model)
@@ -126,7 +126,7 @@ internal extension ServiceModelCodeGenerator {
             setupBuilder = "let converted\(capitalizedVariableName) = \(variableName)"
         } else {
             let fieldType = "[\(baseName)Model.\(typeName)]\(optionalInfix)"
-            setupBuilder = "let converted\(capitalizedVariableName): \(fieldType) = \(failPostix)\(variableName)\(optionalInfix).map { entry in\n"
+            setupBuilder = "let converted\(capitalizedVariableName): \(fieldType) = \(failPostfix)\(variableName)\(optionalInfix).map { entry in\n"
 
             if let setup = conversionDetails.setup {
                 setup.split(separator: "\n").forEach { line in setupBuilder += "    \(line)\n" }
@@ -144,7 +144,7 @@ internal extension ServiceModelCodeGenerator {
                                                  valueType: String, variableName: String,
                                                  isRequired: Bool) -> (setup: String?, fieldShape: String) {
         let willConversionFail = willShapeConversionFail(fieldName: valueType, alreadySeenShapes: [])
-        let failPostix = willConversionFail ? "try " : ""
+        let failPostfix = willConversionFail ? "try " : ""
         let optionalInfix = isRequired ? "" : "?"
 
         let keyTypeName = keyType.getNormalizedTypeName(forModel: model)
@@ -163,7 +163,7 @@ internal extension ServiceModelCodeGenerator {
         
         // if there is actually conversion on each element
         if conversionDetails.conversion != "entry" {
-            var setupBuilder = "let converted\(capitalizedVariableName): \(fieldType) = \(failPostix)\(variableName)\(optionalInfix).mapValues { entry in\n"
+            var setupBuilder = "let converted\(capitalizedVariableName): \(fieldType) = \(failPostfix)\(variableName)\(optionalInfix).mapValues { entry in\n"
 
             if let setup = conversionDetails.setup {
                 setup.split(separator: "\n").forEach { line in setupBuilder += "    \(line)\n" }
@@ -205,9 +205,9 @@ internal extension ServiceModelCodeGenerator {
             let optionalInfix = isRequired ? "" : "?"
             
             let willConversionFail = willShapeConversionFail(fieldName: fieldName, alreadySeenShapes: [])
-            let failPostix = willConversionFail ? "try " : ""
+            let failPostfix = willConversionFail ? "try " : ""
             
-            fieldShape = "\(failPostix)\(variableName)\(optionalInfix).as\(baseName)Model\(fieldName)()"
+            fieldShape = "\(failPostfix)\(variableName)\(optionalInfix).as\(baseName)Model\(fieldName)()"
         }
         
         return (fieldShape, setup)

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+shapeConversion.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+shapeConversion.swift
@@ -230,6 +230,8 @@ internal extension ServiceModelCodeGenerator {
                 }
             case .list(type: let type, lengthConstraint: _):
                 return willShapeConversionFail(fieldName: type, alreadySeenShapes: newAlreadySeenShapes)
+            case .map( keyType: _, let valueType, lengthConstraint: _ ):
+                return willShapeConversionFail( fieldName: valueType, alreadySeenShapes: newAlreadySeenShapes )
             default:
                 break
             }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change adds the map case for the willShapeConversionFail check, allowing shape conversion functions to be tagged with the proper `failPostfix` (i.e., `""` vs `" throws"`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
