### PR TITLE
Update int64 as long type, and generate as Int64 in Swift model type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,16 +21,6 @@ matrix:
       sudo: required
       services: docker
       env: DOCKER_IMAGE_TAG=swift:5.1-xenial USE_SWIFT_LINT=yes
-    - os: linux
-      dist: xenial
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.0.1-bionic USE_SWIFT_LINT=yes
-    - os: linux
-      dist: xenial
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.0.1-xenial USE_SWIFT_LINT=yes
 
 before_install:
   - docker pull $DOCKER_IMAGE_TAG

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelTypes.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelTypes.swift
@@ -194,7 +194,7 @@ public extension ServiceModelCodeGenerator {
         case .double:
             innerType = overrideType ?? "Double"
         case .long:
-            innerType = overrideType ?? "Int"
+            innerType = overrideType ?? "Int64"
         case .timestamp:
             innerType = overrideType ?? "String"
         case .data:

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+shapeUtilityFunctions.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+shapeUtilityFunctions.swift
@@ -109,7 +109,7 @@ public extension ServiceModelCodeGenerator {
             case .double:
                 fieldShape = "Double"
             case .long:
-                fieldShape = "Int"
+                fieldShape = "Int64"
             case .timestamp:
                 fieldShape = "String"
             case .data:

--- a/Sources/SwaggerServiceModel/SwaggerServiceModel+createSwaggerModel.swift
+++ b/Sources/SwaggerServiceModel/SwaggerServiceModel+createSwaggerModel.swift
@@ -294,12 +294,23 @@ internal extension SwaggerServiceModel {
                     exclusiveMinimum: item.metadata?.exclusiveMinimum ?? false,
                     exclusiveMaximum: item.metadata?.exclusiveMaximum ?? false))
         case .integer(item: let item):
-            model.fieldDescriptions[fieldName] =
+            if item.format == IntegerFormat.int64 {
+                model.fieldDescriptions[fieldName] =
+                    Fields.long(rangeConstraint: NumericRangeConstraint<Int>(
+                    minimum: item.metadata?.minimum,
+                    maximum: item.metadata?.maximum,
+                    exclusiveMinimum: item.metadata?.exclusiveMinimum ?? false,
+                    exclusiveMaximum: item.metadata?.exclusiveMaximum ?? false))
+            } else {
+                model.fieldDescriptions[fieldName] =
                 Fields.integer(rangeConstraint: NumericRangeConstraint<Int>(
                     minimum: item.metadata?.minimum,
                     maximum: item.metadata?.maximum,
                     exclusiveMinimum: item.metadata?.exclusiveMinimum ?? false,
                     exclusiveMaximum: item.metadata?.exclusiveMaximum ?? false))
+            }
+            
+        
         case .boolean:
             model.fieldDescriptions[fieldName] = Fields.boolean
         default:

--- a/Sources/SwaggerServiceModel/SwaggerServiceModel+parseSchemas.swift
+++ b/Sources/SwaggerServiceModel/SwaggerServiceModel+parseSchemas.swift
@@ -27,12 +27,20 @@ internal extension SwaggerServiceModel {
         switch schema.type {
         case .boolean:
             model.fieldDescriptions[enclosingEntityName] = .boolean
-        case .integer(_, let metadata):
+        case .integer(.int32, let metadata),.integer(.none, let metadata) :
+            
             model.fieldDescriptions[enclosingEntityName] = Fields.integer(rangeConstraint:
                 NumericRangeConstraint<Int>(minimum: metadata.minimum,
                                             maximum: metadata.maximum,
                                             exclusiveMinimum: metadata.exclusiveMinimum ?? false,
                                             exclusiveMaximum: metadata.exclusiveMaximum ?? false))
+        case .integer(.int64, let metadata):
+            model.fieldDescriptions[enclosingEntityName] = Fields.long(rangeConstraint:
+                NumericRangeConstraint<Int>(minimum: metadata.minimum,
+                                            maximum: metadata.maximum,
+                                            exclusiveMinimum: metadata.exclusiveMinimum ?? false,
+                                            exclusiveMaximum: metadata.exclusiveMaximum ?? false))
+            
         case .structure(let structureSchema):
             var structureDescription = StructureDescription()
             parseStructureSchema(structureDescription: &structureDescription, enclosingEntityName: &enclosingEntityName,


### PR DESCRIPTION
*Issue #, if available:*
Smoke framework does not generate int64 type correctly

*Description of changes:*
Update type and structure generator, to generate int64 type in Swift

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
