### PR TITLE
Don't generate a conversion extension for a collection of built-in types.

### DIFF
--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateConversionFunctions.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateConversionFunctions.swift
@@ -53,7 +53,12 @@ extension ServiceModelCodeGenerator {
                }
             }
             """)
-        case .collectionType(let whereClause):
+        case .collectionType(let whereClause, let builtInInnerTypes):
+            // don't need this extension if everything is builtin
+            if builtInInnerTypes {
+                return
+            }
+            
             fileBuilder.appendLine("""
             
             public extension Array where \(whereClause) {
@@ -106,7 +111,12 @@ extension ServiceModelCodeGenerator {
                }
             }
             """)
-        case .collectionType(let whereClause):
+        case .collectionType(let whereClause, let builtInInnerTypes):
+            // don't need this extension if everything is builtin
+            if builtInInnerTypes {
+                return
+            }
+            
             fileBuilder.appendLine("""
             
             public extension Dictionary where Key == String, \(whereClause) {

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+shapeUtilityFunctions.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+shapeUtilityFunctions.swift
@@ -23,7 +23,7 @@ private let reservedWords: Set<String> = ["in", "protocol", "return", "default",
 
 public enum ShapeCategory {
     case protocolType(String)
-    case collectionType(String)
+    case collectionType(String, builtInInnerTypes: Bool)
     case enumType
     case builtInType(String)
 }
@@ -172,13 +172,28 @@ public extension ServiceModelCodeGenerator {
                 shapeCategory = .builtInType("Data")
             case .list(type: let type, lengthConstraint: _):
                 let typeName = type.getNormalizedTypeName(forModel: model)
+                                
+                let builtInInnerTypes: Bool
+                if case .builtInType = getShapeCategory(fieldName: typeName, collectionAssociatedType: collectionAssociatedType) {
+                    builtInInnerTypes = true
+                } else {
+                    builtInInnerTypes = false
+                }
                 
-                shapeCategory = .collectionType("\(collectionAssociatedType) == [\(typeName)]")
+                shapeCategory = .collectionType("\(collectionAssociatedType) == [\(typeName)]", builtInInnerTypes: builtInInnerTypes)
             case .map(keyType: let keyType, valueType: let valueType, lengthConstraint: _):
                 let keyTypeName = keyType.getNormalizedTypeName(forModel: model)
                 let valueTypeName = valueType.getNormalizedTypeName(forModel: model)
                 
-                shapeCategory = .collectionType("\(collectionAssociatedType) == [\(keyTypeName): \(valueTypeName)]")
+                let builtInInnerTypes: Bool
+                if case .builtInType = getShapeCategory(fieldName: keyTypeName, collectionAssociatedType: collectionAssociatedType),
+                   case .builtInType = getShapeCategory(fieldName: valueTypeName, collectionAssociatedType: collectionAssociatedType) {
+                    builtInInnerTypes = true
+                } else {
+                    builtInInnerTypes = false
+                }
+                
+                shapeCategory = .collectionType("\(collectionAssociatedType) == [\(keyTypeName): \(valueTypeName)]", builtInInnerTypes: builtInInnerTypes)
             }
         } else if fieldName.isBuiltinType {
             shapeCategory = .builtInType(fieldName)


### PR DESCRIPTION
…pes.

*Issue #, if available:* 

*Description of changes:* Don't generate a conversion extension for a collection of built-in types.

A conversion extension (which is useful when converting between compatible shape protocols from different models) is not required for a collection that consists of completely built-in types (ie. a [String] or even a [[String]] will be the same type in different models so no conversion is required).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
