### PR TITLE
Add support for mock function type overrides.

### DIFF
--- a/Sources/ServiceModelCodeGeneration/FileBuilder.swift
+++ b/Sources/ServiceModelCodeGeneration/FileBuilder.swift
@@ -22,6 +22,7 @@ import Foundation
 public class FileBuilder {
     private(set) var builder: String = ""
     private var indentation: Int = 0
+    private var isInCommentBlock = false
     
     /// Default initializer.
     public init() {
@@ -31,6 +32,22 @@ public class FileBuilder {
     /// Appends an empty line to the output.
     public func appendEmptyLine() {
         builder += "\n"
+    }
+    
+    public func inCommentBlock(body: () -> ()) {
+        self.isInCommentBlock = true
+        
+        body()
+        
+        self.isInCommentBlock = false
+    }
+    
+    public func inCommentBlock(body: () throws -> ()) throws {
+        self.isInCommentBlock = true
+        
+        try body()
+        
+        self.isInCommentBlock = false
     }
     
     /**
@@ -57,6 +74,10 @@ public class FileBuilder {
         // add spaces based on the current indentation
         for _ in 0..<indentation {
             builder += "    "
+        }
+        
+        if isInCommentBlock {
+            builder += " "
         }
         
         builder += content

--- a/Sources/ServiceModelCodeGeneration/ModelClientDelegate.swift
+++ b/Sources/ServiceModelCodeGeneration/ModelClientDelegate.swift
@@ -32,9 +32,7 @@ public protocol ModelClientDelegate {
     var clientType: ClientType { get }
 
     var asyncAwaitGeneration: AsyncAwaitGeneration { get }
-    
-    func getFileDescription(isGenerator: Bool) -> String
-    
+        
     /**
      Add any custom file headers to the client file.
  
@@ -47,6 +45,19 @@ public protocol ModelClientDelegate {
                              delegate: ModelClientDelegate,
                              fileBuilder: FileBuilder,
                              isGenerator: Bool)
+    
+    /**
+     Adds the type description to the header comment.
+ 
+     - Parameters:
+        - codeGenerator: The code generator being used.
+        - delegate: the delegate being used.
+        - fileBuilder: The FileBuilder to output to.
+     */
+    func addTypeDescription(codeGenerator: ServiceModelCodeGenerator,
+                            delegate: ModelClientDelegate,
+                            fileBuilder: FileBuilder,
+                            isGenerator: Bool)
     
     /**
      Add any common functions to the body of the client type.

--- a/Sources/ServiceModelGenerate/ClientProtocolDelegate.swift
+++ b/Sources/ServiceModelGenerate/ClientProtocolDelegate.swift
@@ -63,21 +63,43 @@ public struct ClientProtocolDelegate: ModelClientDelegate {
         for (name, operationDescription) in sortedOperations {
             codeGenerator.addOperation(fileBuilder: fileBuilder, name: name,
                                        operationDescription: operationDescription,
-                                       delegate: delegate, invokeType: .eventLoopFutureAsync,
+                                       delegate: delegate, operationInvokeType: .eventLoopFutureAsync,
                                        forTypeAlias: true, isGenerator: isGenerator)
         }
         
-        // for each of the operations
+        // if there is async/await support
         if case .experimental = self.asyncAwaitGeneration {
+            // add async typealiases for Swift 5.5 and greater
             for (index, operation) in sortedOperations.enumerated() {
                 let (name, operationDescription) = operation
                 
                 codeGenerator.addOperation(fileBuilder: fileBuilder, name: name,
                                            operationDescription: operationDescription,
-                                           delegate: delegate, invokeType: .asyncFunction,
+                                           delegate: delegate, operationInvokeType: .asyncFunction,
                                            forTypeAlias: true, isGenerator: isGenerator,
-                                           prefixLine: (index == 0) ? "#if compiler(>=5.5) && $AsyncAwait" : nil,
+                                           prefixLine: (index == 0) ? "#if compiler(>=5.5)" : nil,
+                                           postfixLine: (index == sortedOperations.count - 1) ? "#else" : nil)
+            }
+            
+            // add sync typealiases for Swift 5.5 and greater
+            for (index, operation) in sortedOperations.enumerated() {
+                let (name, operationDescription) = operation
+                
+                codeGenerator.addOperation(fileBuilder: fileBuilder, name: name,
+                                           operationDescription: operationDescription,
+                                           delegate: delegate, operationInvokeType: .syncFunctionForNoAsyncAwaitSupport,
+                                           forTypeAlias: true, isGenerator: isGenerator,
                                            postfixLine: (index == sortedOperations.count - 1) ? "#endif" : nil)
+            }
+        // otherwise just add sync typealiases
+        } else {
+            for operation in sortedOperations {
+                let (name, operationDescription) = operation
+                
+                codeGenerator.addOperation(fileBuilder: fileBuilder, name: name,
+                                           operationDescription: operationDescription,
+                                           delegate: delegate, operationInvokeType: .syncFunctionForNoAsyncAwaitSupport,
+                                           forTypeAlias: true, isGenerator: isGenerator)
             }
         }
     }

--- a/Sources/ServiceModelGenerate/ClientProtocolDelegate.swift
+++ b/Sources/ServiceModelGenerate/ClientProtocolDelegate.swift
@@ -43,8 +43,11 @@ public struct ClientProtocolDelegate: ModelClientDelegate {
         self.asyncAwaitGeneration = asyncAwaitGeneration
     }
     
-    public func getFileDescription(isGenerator: Bool) -> String {
-        return self.typeDescription
+    public func addTypeDescription(codeGenerator: ServiceModelCodeGenerator,
+                                   delegate: ModelClientDelegate,
+                                   fileBuilder: FileBuilder,
+                                   isGenerator: Bool) {
+        fileBuilder.appendLine(self.typeDescription)
     }
     
     public func addCustomFileHeader(codeGenerator: ServiceModelCodeGenerator,

--- a/Sources/ServiceModelGenerate/MockClientDelegate.swift
+++ b/Sources/ServiceModelGenerate/MockClientDelegate.swift
@@ -45,19 +45,19 @@ public struct MockClientDelegate: ModelClientDelegate {
         self.asyncAwaitGeneration = asyncAwaitGeneration
         
         let name: String
-        let additionalConformingProtocol: String
+        let implementationProviderProtocol: String
         if isThrowingMock {
             name = "Throwing\(baseName)Client"
-            additionalConformingProtocol = "MockThrowingClientProtocol"
+            implementationProviderProtocol = "MockThrowingClientProtocol"
             self.defaultBehaviourDescription = "throw the error provided at initialization."
         } else {
             name = "Mock\(baseName)Client"
-            additionalConformingProtocol = "MockClientProtocol"
+            implementationProviderProtocol = "MockClientProtocol"
             self.defaultBehaviourDescription = "return the `__default` property of its return type."
         }
         
         self.clientType = .struct(name: name, genericParameters: [],
-                                  conformingProtocolNames: ["\(baseName)ClientProtocol", additionalConformingProtocol])
+                                  conformingProtocolNames: ["\(baseName)ClientProtocol", implementationProviderProtocol])
     }
     
     public func addTypeDescription(codeGenerator: ServiceModelCodeGenerator,

--- a/Sources/ServiceModelGenerate/MockClientDelegate.swift
+++ b/Sources/ServiceModelGenerate/MockClientDelegate.swift
@@ -94,7 +94,7 @@ public struct MockClientDelegate: ModelClientDelegate {
         
         let variableName = name.upperToLowerCamelCase
         fileBuilder.appendLine("\(variableName)EventLoopFutureAsync: \(name.startingWithUppercase)EventLoopFutureAsyncType? = nil,")
-        fileBuilder.appendLine("\(variableName)FunctionType: \(name.startingWithUppercase)FunctionType? = nil\(postfix)")
+        fileBuilder.appendLine("\(variableName): \(name.startingWithUppercase)FunctionType? = nil\(postfix)")
     }
     
     public func addCommonFunctions(codeGenerator: ServiceModelCodeGenerator,
@@ -115,7 +115,7 @@ public struct MockClientDelegate: ModelClientDelegate {
         for (name, _) in sortedOperations {
             let variableName = name.upperToLowerCamelCase
             fileBuilder.appendLine("let \(variableName)EventLoopFutureAsyncOverride: \(name.startingWithUppercase)EventLoopFutureAsyncType?")
-            fileBuilder.appendLine("let \(variableName)FunctionTypeOverride: \(name.startingWithUppercase)FunctionType?")
+            fileBuilder.appendLine("let \(variableName)FunctionOverride: \(name.startingWithUppercase)FunctionType?")
         }
         fileBuilder.appendEmptyLine()
         
@@ -173,7 +173,7 @@ public struct MockClientDelegate: ModelClientDelegate {
         for (name, _) in sortedOperations {
             let variableName = name.upperToLowerCamelCase
             fileBuilder.appendLine("self.\(variableName)EventLoopFutureAsyncOverride = \(variableName)EventLoopFutureAsync")
-            fileBuilder.appendLine("self.\(variableName)FunctionTypeOverride = \(variableName)FunctionType")
+            fileBuilder.appendLine("self.\(variableName)FunctionOverride = \(variableName)")
         }
         
         fileBuilder.decIndent()
@@ -224,16 +224,16 @@ public struct MockClientDelegate: ModelClientDelegate {
                         input: input,
                         defaultResult: \(typeName).__default,
                         eventLoop: self.eventLoop,
-                        functionTypeOverride: self.\(variableName)FunctionTypeOverride,
-                        eventLoopFutureTypeOverride: self.\(variableName)EventLoopFutureAsyncOverride)
+                        functionOverride: self.\(variableName)FunctionOverride,
+                        eventLoopFutureFunctionOverride: self.\(variableName)EventLoopFutureAsyncOverride)
                     """)
             } else {
                 fileBuilder.appendLine("""
                     return \(functionPrefix)mock\(functionInfix)ExecuteWithoutInputWithOutput(
                         defaultResult: \(typeName).__default,
                         eventLoop: self.eventLoop,
-                        functionTypeOverride: self.\(variableName)FunctionTypeOverride,
-                        eventLoopFutureTypeOverride: self.\(variableName)EventLoopFutureAsyncOverride)
+                        functionOverride: self.\(variableName)FunctionOverride,
+                        eventLoopFutureFunctionOverride: self.\(variableName)EventLoopFutureAsyncOverride)
                     """)
             }
         } else {
@@ -242,15 +242,15 @@ public struct MockClientDelegate: ModelClientDelegate {
                     return \(functionPrefix)mock\(functionInfix)ExecuteWithInputWithoutOutput(
                         input: input,
                         eventLoop: self.eventLoop,
-                        functionTypeOverride: self.\(variableName)FunctionTypeOverride,
-                        eventLoopFutureTypeOverride: self.\(variableName)EventLoopFutureAsyncOverride)
+                        functionOverride: self.\(variableName)FunctionOverride,
+                        eventLoopFutureFunctionOverride: self.\(variableName)EventLoopFutureAsyncOverride)
                     """)
             } else {
                 fileBuilder.appendLine("""
                     return \(functionPrefix)mock\(functionInfix)ExecuteWithoutInputWithoutOutput(
                         eventLoop: self.eventLoop,
-                        functionTypeOverride: self.\(variableName)FunctionTypeOverride,
-                        eventLoopFutureTypeOverride: self.\(variableName)EventLoopFutureAsyncOverride)
+                        functionOverride: self.\(variableName)FunctionOverride,
+                        eventLoopFutureFunctionOverride: self.\(variableName)EventLoopFutureAsyncOverride)
                     """)
             }
         }
@@ -324,16 +324,16 @@ public struct MockClientDelegate: ModelClientDelegate {
                         input: input,
                         defaultError: self.error,
                         eventLoop: self.eventLoop,
-                        functionTypeOverride: self.\(variableName)FunctionTypeOverride,
-                        eventLoopFutureTypeOverride: self.\(variableName)EventLoopFutureAsyncOverride)
+                        functionOverride: self.\(variableName)FunctionOverride,
+                        eventLoopFutureFunctionOverride: self.\(variableName)EventLoopFutureAsyncOverride)
                     """)
             } else {
                 fileBuilder.appendLine("""
                     return \(functionPrefix)mockThrowing\(functionInfix)ExecuteWithoutInputWithOutput(
                         defaultError: self.error,
                         eventLoop: self.eventLoop,
-                        functionTypeOverride: self.\(variableName)FunctionTypeOverride,
-                        eventLoopFutureTypeOverride: self.\(variableName)EventLoopFutureAsyncOverride)
+                        functionOverride: self.\(variableName)FunctionOverride,
+                        eventLoopFutureFunctionOverride: self.\(variableName)EventLoopFutureAsyncOverride)
                     """)
             }
         } else {
@@ -343,16 +343,16 @@ public struct MockClientDelegate: ModelClientDelegate {
                         input: input,
                         defaultError: self.error,
                         eventLoop: self.eventLoop,
-                        functionTypeOverride: self.\(variableName)FunctionTypeOverride,
-                        eventLoopFutureTypeOverride: self.\(variableName)EventLoopFutureAsyncOverride)
+                        functionOverride: self.\(variableName)FunctionOverride,
+                        eventLoopFutureFunctionOverride: self.\(variableName)EventLoopFutureAsyncOverride)
                     """)
             } else {
                 fileBuilder.appendLine("""
                     return \(functionPrefix)mockThrowing\(functionInfix)ExecuteWithoutInputWithoutOutput(
                         defaultError: self.error,
                         eventLoop: self.eventLoop,
-                        functionTypeOverride: self.\(variableName)FunctionTypeOverride,
-                        eventLoopFutureTypeOverride: self.\(variableName)EventLoopFutureAsyncOverride)
+                        functionOverride: self.\(variableName)FunctionOverride,
+                        eventLoopFutureFunctionOverride: self.\(variableName)EventLoopFutureAsyncOverride)
                     """)
             }
         }

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateClient.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateClient.swift
@@ -39,7 +39,6 @@ public extension ServiceModelCodeGenerator {
         let baseName = applicationDescription.baseName
         
         let typeName: String
-        let typeDescription = delegate.getFileDescription(isGenerator: isGenerator)
         
         let typePostfix = isGenerator ? "Generator" : ""
         
@@ -81,7 +80,14 @@ public extension ServiceModelCodeGenerator {
         fileBuilder.appendLine("""
             
             /**
-             \(typeDescription)
+            """)
+        
+        fileBuilder.inCommentBlock {
+            delegate.addTypeDescription(codeGenerator: self, delegate: delegate,
+                                        fileBuilder: fileBuilder, isGenerator: isGenerator)
+        }
+
+        fileBuilder.appendLine("""
              */
             public \(typeDecaration) {
             """)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add support for mock function type overrides.

TLDR: The upshot of these changes is an application should be able to add an sync override to the mock or throwing implementations with Swift 5.4 and it will be treated as an async function by the compiler in Swift 5.5 without any application code changes (and could be converted to an async function sometime later if required).

If code generated with the asyncAwaitGeneration:client set to NONE (currently hard-coded by some-framework-application-generate)-
1. Will create an alternate set of override input functions for the mock and mock throwing client implementations that are sync functions
2. The mock and throwing implementations call into the functions added here [1] and [2]. These will use the new override functions if they exist, otherwise use the existing EventLoopFuture-returning overrides if they exist, otherwise return a default or throw an error depending on the implementation

This is an example of the code generated changes - [3]

If code generated with the asyncAwaitGeneration:client set to EXPERIMENTAL-
1. Will create an alternate set of override input functions for the mock and mock throwing client implementations that are sync functions if compiled under Swift 5.4 or earlier or async functions of compiled under Swift 5.5 or later (and supporting Apple platforms)
2. The mock and throwing implementations call into the functions added here [1] and [2] for Swift 5.4 and earlier and [4] and [5] for Swift 5.5 and later. These will use the new override functions if they exist, otherwise use the existing EventLoopFuture-returning overrides if they exist, otherwise return a default or throw an error depending on the implementation.

This is an example of the code generated changes - [6]

*Testing:*

Tested application consuming a client and using a sync function override both with asyncAwaitGeneration:client set to NONE and EXPERIMENTAL.
1. Both variants of the client compiled under 5.4.1 and 5.5 nightly without any application changes.
2. The asyncAwaitGeneration:client set to EXPERIMENTAL client compiled under Swift 5.5 allowed the function override to be made async by adding the `async` keyword.

[1] https://github.com/amzn/smoke-aws/blob/mock_and_mock_throwing_implementations/Sources/SmokeAWSHttp/MockClientProtocol.swift
[2] https://github.com/amzn/smoke-aws/blob/mock_and_mock_throwing_implementations/Sources/SmokeAWSHttp/MockThrowingClientProtocol.swift
[3] https://github.com/amzn/smoke-framework-examples/commit/bb77a4728606551c6de2aa6ae8e3229690316fa8
[4] https://github.com/amzn/smoke-aws/blob/mock_and_mock_throwing_implementations/Sources/_SmokeAWSHttpConcurrency/MockClientProtocol.swift
[5] https://github.com/amzn/smoke-aws/blob/mock_and_mock_throwing_implementations/Sources/_SmokeAWSHttpConcurrency/MockThrowingClientProtocol.swift
[6] https://github.com/amzn/smoke-framework-examples/commit/c5c50f65a721260e0e44a30e3e23e9ab44492044


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
