### PR TITLE
Create OpenAPIServiceModel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ before_install:
   - docker pull $DOCKER_IMAGE_TAG
 
 script:
-  - docker run -v ${TRAVIS_BUILD_DIR}:/package ${DOCKER_IMAGE_TAG} /bin/bash -c "/package/CITests/run $ONLY_RUN_SWIFT_LINT $USE_APT_GET"
+  - docker run -v ${TRAVIS_BUILD_DIR}:/package ${DOCKER_IMAGE_TAG} /bin/bash -c "/package/CITests/run $ONLY_RUN_SWIFT_LINT $USE_APT_GET $DOCKER_IMAGE_TAG"

--- a/CITests/run
+++ b/CITests/run
@@ -3,6 +3,7 @@ set -e
 
 ONLY_RUN_SWIFT_LINT=$1
 USE_APT_GET=$2
+DOCKER_IMAGE_TAG=$3
 
 if [ "$USE_APT_GET" == 'yes' ]; then
     apt-get update
@@ -14,6 +15,9 @@ cd /package
 if [ "$ONLY_RUN_SWIFT_LINT" == 'yes' ]; then
     ls
     swiftlint
+# Temporary work around for swift 5.4 build errors with OpenAPIKit
+elif [ "$DOCKER_IMAGE_TAG" == 'swift:5.4.0-amazonlinux2' ]; then
+   swift build -Xswiftc -Xfrontend -Xswiftc -sil-verify-none -c release
 else
     swift build -c release
     #swift test

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,7 +5,7 @@
         "package": "OpenAPIKit",
         "repositoryURL": "https://github.com/mndzup/OpenAPIKit.git",
         "state": {
-          "branch": "working",
+          "branch": "main",
           "revision": "84fc477c8e96a7013269a355f1f5734dd70e53f7",
           "version": null
         }

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "OpenAPIKit",
+        "repositoryURL": "https://github.com/mndzup/OpenAPIKit.git",
+        "state": {
+          "branch": "working",
+          "revision": "84fc477c8e96a7013269a355f1f5734dd70e53f7",
+          "version": null
+        }
+      },
+      {
         "package": "SwaggerParser",
         "repositoryURL": "https://github.com/tachyonics/SwaggerParser.git",
         "state": {
@@ -15,8 +24,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "9003d51672e516cc59297b7e96bff1dfdedcb4ea",
-          "version": "4.0.4"
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/tachyonics/SwaggerParser.git", from: "0.6.4"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0"),
-        .package(url: "https://github.com/mndzup/OpenAPIKit.git", .branch("working")),
+        .package(url: "https://github.com/mndzup/OpenAPIKit.git", .branch("main")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -33,10 +33,14 @@ let package = Package(
         .library(
             name: "SwaggerServiceModel",
             targets: ["SwaggerServiceModel"]),
+        .library(
+            name: "OpenAPIServiceModel",
+            targets: ["OpenAPIServiceModel"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tachyonics/SwaggerParser.git", from: "0.6.4"), 
+        .package(url: "https://github.com/tachyonics/SwaggerParser.git", from: "0.6.4"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0"),
+        .package(url: "https://github.com/mndzup/OpenAPIKit.git", .branch("working")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -55,6 +59,15 @@ let package = Package(
                 .target(name: "ServiceModelCodeGeneration"),
                 .product(name: "Yams", package: "Yams"),
                 .product(name: "SwaggerParser", package: "SwaggerParser"),
+                .product(name: "OpenAPIKit" , package: "OpenAPIKit"),
+            ]
+        ),
+        .target(
+            name: "OpenAPIServiceModel", dependencies: [
+                .target(name: "ServiceModelCodeGeneration"),
+                .product(name: "Yams", package: "Yams"),
+                .product(name: "SwaggerParser", package: "SwaggerParser"),
+                .product(name: "OpenAPIKit" , package: "OpenAPIKit"),
             ]
         ),
         .target(

--- a/Sources/OpenAPIServiceModel/CreateOpenAPIServiceModel.swift
+++ b/Sources/OpenAPIServiceModel/CreateOpenAPIServiceModel.swift
@@ -1,0 +1,382 @@
+// Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// CreateOpenAPIServiceModel.swift
+// OpenAPIServiceModel
+//
+
+import Foundation
+import OpenAPIKit
+import ServiceModelEntities
+import ServiceModelCodeGeneration
+import Yams
+internal extension OpenAPIServiceModel {
+    struct OperationInputMembers {
+        var queryMembers: [String: Member] = [:]
+        var additionalHeaderMembers: [String: Member] = [:]
+        var pathMembers: [String: Member] = [:]
+    }
+    
+    static func filterOperations(operations: [OpenAPI.HttpMethod: OpenAPI.Operation],
+                                 modelOverride: ModelOverride?) -> [OpenAPI.HttpMethod: OpenAPI.Operation] {
+        
+        guard let ignoreOperations = modelOverride?.ignoreOperations else {
+            return operations
+        }
+        
+        var filteredOperations: [OpenAPI.HttpMethod: OpenAPI.Operation] = [:]
+        
+        operations.forEach { (key, value) in
+            if ignoreOperations.contains("*.*") {
+                return
+            }
+            
+            if ignoreOperations.contains("*.\(key.rawValue)") {
+                return
+            }
+            
+            if let identifier = value.operationId {
+                if ignoreOperations.contains("\(identifier).\(key.rawValue)") {
+                    return
+                }
+                
+                if ignoreOperations.contains("\(identifier).*") {
+                    return
+                }
+            }
+            
+            filteredOperations[key] = value
+        }
+        
+        return filteredOperations
+    }
+    
+    static func createOpenAPIModel(definition: OpenAPI.Document, modelOverride: ModelOverride?) -> OpenAPIServiceModel {
+        var model = OpenAPIServiceModel()
+
+        for (name, schema) in definition.components.schemas {
+            var enclosingEntityName = name.rawValue
+            parseDefinitionSchemas(model: &model, enclosingEntityName: &enclosingEntityName,
+                                   schema: schema, modelOverride: modelOverride, document: definition)
+        }
+        
+        for (path, pathDefinition) in definition.paths {
+            var operations:[OpenAPI.HttpMethod: OpenAPI.Operation] = [:]
+            
+            pathDefinition.endpoints.forEach { endpoint in
+                operations[endpoint.method] = endpoint.operation
+            }
+            
+            let filteredOperations = filterOperations(operations: operations,
+                                                      modelOverride: modelOverride)
+            
+            for (type, operation) in filteredOperations {
+                guard let operationName = operation.operationId else {
+                    continue
+                }
+                
+                let inputDescription =
+                        OperationInputDescription(defaultInputLocation: .body)
+                
+                var operationDescription = OperationDescription(
+                    inputDescription: inputDescription,
+                    outputDescription: OperationOutputDescription())
+                operationDescription.httpUrl = path.rawValue
+                operationDescription.httpVerb = type.rawValue.uppercased()
+                
+                parseOperation(description: &operationDescription,
+                               operationName: operationName,
+                               model: &model, operation: operation,
+                               modelOverride: modelOverride, document: definition)
+                
+                model.operationDescriptions[operationName] = operationDescription
+            }
+        }
+        
+        return model
+    }
+    
+    static func parseOperation(description: inout OperationDescription,
+                               operationName: String,
+                               model: inout OpenAPIServiceModel,
+                               operation: OpenAPI.Operation,
+                               modelOverride: ModelOverride?,
+                               document: OpenAPI.Document) {
+        let (members, bodyStructureName) = getOperationMembersAndBodyStructureName(
+            operation: operation,
+                            operationName: operationName,
+                            model: &model,
+                            modelOverride: modelOverride, document: document)
+        
+        setOperationInput(bodyStructureName: bodyStructureName, operationInputMembers: members,
+                          description: &description, model: &model, operationName: operationName)
+        
+        setOperationOutput(operation: operation, operationName: operationName, model: &model,
+                           modelOverride: modelOverride, description: &description, document: document)
+    }
+    
+    static func getOperationMembersAndBodyStructureName(
+            operation: OpenAPI.Operation,
+            operationName: String,
+            model: inout OpenAPIServiceModel,
+            modelOverride: ModelOverride?, document: OpenAPI.Document) -> (members: OperationInputMembers, bodyStructureName: String?) {
+        var members = OperationInputMembers()
+        var bodyStructureName: String?
+        
+        if let requestBody = operation.requestBody?.b {
+            getBodyOperationMembers(requestBody, bodyStructureName: &bodyStructureName,
+                                    operationName: operationName, model: &model, modelOverride: modelOverride, document: document)
+        } else {
+            fatalError("no request body")
+        }
+        
+        for (index, parameter) in operation.parameters.enumerated() {
+            switch parameter {
+            case .b(let value):
+                switch value.context.location {
+                case .cookie, .header, .path, .query:
+                    if let schemaValue = value.schemaOrContent.schemaValue {
+                        getFixedFieldsOperationMembers(fixedFields: value, operationName: operationName,
+                                                       index: index, members: &members, items: schemaValue,
+                                                       model: &model, modelOverride: modelOverride)
+                    }
+                }
+            case .a(_):
+                fatalError("Not implemented.")
+            }
+        }
+        
+        return (members: members, bodyStructureName: bodyStructureName)
+    }
+    
+    static func getBodyOperationMembers(_ request: OpenAPI.Request, bodyStructureName: inout String?,
+                                        operationName: String, model: inout OpenAPIServiceModel,
+                                        modelOverride: ModelOverride?, document: OpenAPI.Document) {
+        for (_,value) in request.content {
+            if let schema = value.schema?.b {
+                switch schema {
+                case .object:
+                    var enclosingEntityName = "\(operationName)RequestBody"
+                    var structureDescription = StructureDescription()
+                    guard let objectContext = schema.objectContext else {
+                       continue
+                    }
+                    parseObjectSchema(structureDescription: &structureDescription, enclosingEntityName: &enclosingEntityName,
+                                      model: &model, objectContext: objectContext, modelOverride: modelOverride, document: document)
+                    
+                    model.structureDescriptions[enclosingEntityName] = structureDescription
+                    
+                    bodyStructureName = enclosingEntityName
+                default:
+                    fatalError("Not implemented.")
+                }
+            } else if let reference = value.schema?.a {
+                if let refName = reference.name {
+                    bodyStructureName = refName
+                }
+            }
+        }
+    }
+    
+    static func ignoreRequestHeader(operationName: String, headerName: String,
+                                     modelOverride: ModelOverride?) -> Bool {
+        
+        guard let ignoreRequestHeaders = modelOverride?.ignoreRequestHeaders else {
+            return false
+        }
+        
+        if ignoreRequestHeaders.contains("*.*") {
+            return true
+        }
+        
+        if ignoreRequestHeaders.contains("*.\(headerName)") {
+            return true
+        }
+        
+        if ignoreRequestHeaders.contains("\(operationName).\(headerName)") {
+            return true
+        }
+        
+        if ignoreRequestHeaders.contains("\(operationName).*") {
+            return true
+        }
+        
+        return false
+    }
+    
+    static func getFixedFieldsOperationMembers(fixedFields: OpenAPI.Parameter, operationName: String,
+                                               index: Int, members: inout OpenAPIServiceModel.OperationInputMembers,
+                                               items: JSONSchema, model: inout OpenAPIServiceModel, modelOverride: ModelOverride?) {
+        let typeName = fixedFields.name.safeModelName().startingWithUppercase
+        
+        let fieldName = "\(operationName)Request\(typeName)"
+        let member = Member(value: fieldName,
+                            position: index,
+                            required: fixedFields.required,
+                            documentation: fixedFields.description)
+        switch fixedFields.location {
+        case .query:
+            members.queryMembers[fixedFields.name] = member
+        case .path:
+            members.pathMembers[fixedFields.name] = member
+        case .header:
+            guard !ignoreRequestHeader(operationName: operationName, headerName: fixedFields.name, modelOverride: modelOverride) else {
+                return
+            }
+            
+            members.additionalHeaderMembers[fixedFields.name] = member
+        default:
+            break
+        }
+        
+        addField(item: items, fieldName: fieldName,
+                 model: &model, modelOverride: modelOverride)
+    }
+    
+    static func addOperationResponseFromSchema(schema: JSONSchema, operationName: String, forCode code: Int, index: Int?,
+                                               description: inout OperationDescription,
+                                               model: inout OpenAPIServiceModel, modelOverride: ModelOverride?, document: OpenAPI.Document) {
+        switch schema {
+        case .object:
+            let indexString = index?.description ?? ""
+            var structureName = "\(operationName)\(code)Response\(indexString)Body"
+            var structureDescription = StructureDescription()
+            guard let objectContext = schema.objectContext else {
+                fatalError("Not object")
+            }
+            parseObjectSchema(structureDescription: &structureDescription, enclosingEntityName: &structureName,
+                              model: &model, objectContext: objectContext, modelOverride: modelOverride, document: document)
+            
+            model.structureDescriptions[structureName] = structureDescription
+            
+            if code >= 200 && code < 300 {
+                description.output = structureName
+            } else {
+                description.errors.append((type: structureName, code: code))
+                model.errorTypes.insert(structureName)
+            }
+        default:
+            fatalError("Not implemented.")
+        }
+    }
+    
+    static func addOperationResponseFromReference(reference: JSONReference<JSONSchema>, operationName: String, forCode code: Int,
+                                                  index: Int?, description: inout OperationDescription,
+                                                  model: inout OpenAPIServiceModel, modelOverride: ModelOverride?) {
+        if let refName = reference.name {
+            if code >= 200 && code < 300 {
+                description.output = refName
+            } else {
+                description.errors.append((type: refName, code: code))
+                model.errorTypes.insert(refName)
+            }
+        }
+    }
+    
+    static func addField(item: JSONSchema, fieldName: String,
+                         model: inout OpenAPIServiceModel, modelOverride: ModelOverride?) {
+        switch item {
+        case .string(_, let context):
+            addStringField(metadata: context,
+                           schema: nil,
+                           model: &model,
+                           fieldName: fieldName,
+                           modelOverride: modelOverride)
+        case .number(_, let context):
+            model.fieldDescriptions[fieldName] =
+                Fields.double(rangeConstraint: NumericRangeConstraint<Double>(
+                    minimum: context.minimum?.value,
+                    maximum: context.maximum?.value,
+                    exclusiveMinimum: context.minimum?.exclusive ?? false,
+                    exclusiveMaximum: context.maximum?.exclusive ?? false))
+        case .integer(let integerFormat, let context):
+            if integerFormat.format ==  .int64 {
+                model.fieldDescriptions[fieldName] =
+                    Fields.long(rangeConstraint: NumericRangeConstraint<Int>(
+                    minimum: context.minimum?.value,
+                    maximum: context.maximum?.value,
+                    exclusiveMinimum: context.minimum?.exclusive ?? false,
+                    exclusiveMaximum: context.maximum?.exclusive ?? false))
+            } else {
+                model.fieldDescriptions[fieldName] =
+                Fields.integer(rangeConstraint: NumericRangeConstraint<Int>(
+                    minimum: context.minimum?.value,
+                    maximum: context.maximum?.value,
+                    exclusiveMinimum: context.minimum?.exclusive ?? false,
+                    exclusiveMaximum: context.maximum?.exclusive ?? false))
+            }
+            
+        
+        case .boolean:
+            model.fieldDescriptions[fieldName] = Fields.boolean
+        default:
+            fatalError("Field type not supported.")
+        }
+    }
+
+    static func getEnumerationValues(metadata: JSONSchemaContext) -> [(name: String, value: String)] {
+       let enumerationValues: [(name: String, value: String)]
+        if let allowedValues = metadata.allowedValues {
+            enumerationValues = allowedValues.filter { allowedValue in allowedValue.value is String }
+                .compactMap { allowedValue in allowedValue.value as? String }
+                .map { value in (name: value, value: value) }
+        } else {
+            enumerationValues = []
+        }
+        
+        return enumerationValues
+    }
+
+    static func addStringField(metadata: JSONSchema.StringContext?,
+                               schema: JSONSchema?,
+                               model: inout OpenAPIServiceModel,
+                               fieldName: String,
+                               modelOverride: ModelOverride?) {
+        let pattern: String?
+        let newValueConstraints: [(name: String, value: String)]
+
+        if modelOverride?.modelStringPatternsAreAlternativeList ?? false,
+            let current = metadata?.pattern,
+            let first = current.first, first == "^",
+            let last = current.last, last == "$" {
+                pattern = nil
+                newValueConstraints =
+                    current.dropFirst().dropLast().split(separator: "|").map { subString in
+                        let value = String(subString)
+                        return (name: value, value: value)
+                }
+        } else {
+            pattern = nil
+            if let coreContext = schema?.coreContext {
+                newValueConstraints = getEnumerationValues(metadata: coreContext)
+            } else {
+                newValueConstraints = []
+            }
+        }
+        
+        // If minLength is 0, the field is optional and does not required validation
+        if metadata?.minLength == 0 {
+            model.fieldDescriptions[fieldName] = Fields.string(
+                regexConstraint: pattern,
+                lengthConstraint: LengthRangeConstraint<Int>(minimum: nil,
+                                                            maximum: metadata?.maxLength ?? nil),
+                valueConstraints: newValueConstraints)
+        } else {
+            model.fieldDescriptions[fieldName] = Fields.string(
+                regexConstraint: pattern,
+                lengthConstraint: LengthRangeConstraint<Int>(minimum: metadata?.minLength ?? nil,
+                                                            maximum: metadata?.maxLength ?? nil),
+                valueConstraints: newValueConstraints)
+        }
+    }
+}

--- a/Sources/OpenAPIServiceModel/OpenAPIServiceModel.swift
+++ b/Sources/OpenAPIServiceModel/OpenAPIServiceModel.swift
@@ -1,0 +1,51 @@
+// Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// OpenAPIServiceModel.swift
+// OpenAPIServiceModel
+//
+
+import Foundation
+import OpenAPIKit
+import ServiceModelEntities
+import ServiceModelCodeGeneration
+import Yams
+
+/**
+ Struct that models the Metadata of the OpenAPI  model.
+ */
+public struct OpenAPIServiceModel: ServiceModel {
+    public var serviceDescriptions: [String: ServiceDescription] = [:]
+    public var structureDescriptions: [String: StructureDescription] = [:]
+    public var operationDescriptions: [String: OperationDescription] = [:]
+    public var fieldDescriptions: [String: Fields] = [:]
+    public var errorTypes: Set<String> = []
+    public var typeMappings: [String: String] = [:]
+    public var errorCodeMappings: [String: String] = [:]
+    
+    public static func create(data: Data, modelFormat: ModelFormat,
+                              modelOverride: ModelOverride?) throws -> OpenAPIServiceModel {
+        let definition: OpenAPI.Document
+        switch modelFormat {
+        case .yaml:
+            let decoder = YAMLDecoder()
+            let dataAsString = String(data: data, encoding: .utf8)!
+            definition = try decoder.decode(OpenAPI.Document.self, from: dataAsString)
+        default:
+            let decoder = JSONDecoder()
+            definition = try decoder.decode(OpenAPI.Document.self, from: data)
+        }
+        
+        return createOpenAPIModel(definition: definition, modelOverride: modelOverride)
+    }
+}

--- a/Sources/OpenAPIServiceModel/ParseSchemas.swift
+++ b/Sources/OpenAPIServiceModel/ParseSchemas.swift
@@ -68,7 +68,8 @@ internal extension OpenAPIServiceModel {
                                                                                                            exclusiveMaximum: numberContext.maximum?.exclusive ?? false))
         case .all(let otherSchema, _), .any(let otherSchema, _), .one(let otherSchema, _):
             var structureDescription = StructureDescription()
-            parseOtherSchemas(structureDescription: &structureDescription, enclosingEntityName: &enclosingEntityName, model: &model, otherSchema: otherSchema, modelOverride: modelOverride, document: document)
+            parseOtherSchemas(structureDescription: &structureDescription, enclosingEntityName: &enclosingEntityName,
+                              model: &model, otherSchema: otherSchema, modelOverride: modelOverride, document: document)
         case .reference:
             break
         case .fragment:
@@ -89,6 +90,7 @@ internal extension OpenAPIServiceModel {
             }
             switch property {
             case .reference(let ref):
+                // TODO: Once OpenAPIKit adds optionality for references, replace requiredArray with requiredProperties
                 if let referenceName = ref.name {
                     structureDescription.members[name] = Member(value: referenceName, position: index,
                                                                 required: objectContext.requiredArray.contains(name),
@@ -125,7 +127,6 @@ internal extension OpenAPIServiceModel {
         default:
             fatalError("Not implemented")
         }
-        
     }
     
     static func parseArrayDefinitionSchemas(arrayMetadata: JSONSchema.ArrayContext,
@@ -136,7 +137,7 @@ internal extension OpenAPIServiceModel {
             switch value {
             case .reference(let ref):
                 if let type = ref.name {
-                    // If minItems is 0, the field is optional and does not required validation
+                    // If minItems is 0, the field is optional and does not require validation
                     if arrayMetadata.minItems == 0 {
                         let lengthConstraint = LengthRangeConstraint<Int>(minimum: nil,
                                                                           maximum: arrayMetadata.maxItems)

--- a/Sources/OpenAPIServiceModel/ParseSchemas.swift
+++ b/Sources/OpenAPIServiceModel/ParseSchemas.swift
@@ -1,0 +1,202 @@
+// Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// ParseSchemas.swift
+// OpenAPIServiceModel
+//
+
+import Foundation
+import OpenAPIKit
+import ServiceModelEntities
+import ServiceModelCodeGeneration
+import Yams
+
+internal extension OpenAPIServiceModel {
+    static func parseDefinitionSchemas(model: inout OpenAPIServiceModel, enclosingEntityName: inout String,
+                                       schema: JSONSchema, modelOverride: ModelOverride?, document: OpenAPI.Document) {
+        switch schema {
+        case .boolean:
+            model.fieldDescriptions[enclosingEntityName] = .boolean
+        case .integer(let integerFormat, let integerContext):
+            if integerFormat.format == .int64 {
+                model.fieldDescriptions[enclosingEntityName] = Fields.long(rangeConstraint:
+                                                                            NumericRangeConstraint<Int>(minimum: integerContext.minimum?.value,
+                                                                                                        maximum: integerContext.maximum?.value,
+                                                                                                        exclusiveMinimum: integerContext.minimum?.exclusive ?? false,
+                                                                                                        exclusiveMaximum: integerContext.maximum?.exclusive ?? false))
+            } else {
+                model.fieldDescriptions[enclosingEntityName] = Fields.integer(rangeConstraint:
+                                                                            NumericRangeConstraint<Int>(minimum: integerContext.minimum?.value,
+                                                                                                        maximum: integerContext.maximum?.value,
+                                                                                                        exclusiveMinimum: integerContext.minimum?.exclusive ?? false,
+                                                                                                        exclusiveMaximum: integerContext.maximum?.exclusive ?? false))
+            }
+            
+        case .object(_ , let objectContext):
+            if case .b(let mapSchema) = objectContext.additionalProperties {
+                parseMapDefinitionSchema(mapSchema: mapSchema,
+                                         enclosingEntityName: &enclosingEntityName,
+                                         model: &model)
+            } else {
+                var structureDescription = StructureDescription()
+                parseObjectSchema(structureDescription: &structureDescription, enclosingEntityName: &enclosingEntityName,
+                                  model: &model, objectContext: objectContext, modelOverride: modelOverride, document: document)
+                
+                model.structureDescriptions[enclosingEntityName] = structureDescription
+            }
+        case .array(_, let arrayContext):
+            parseArrayDefinitionSchemas(arrayMetadata: arrayContext, enclosingEntityName: &enclosingEntityName,
+                                        model: &model, modelOverride: modelOverride, document: document)
+        case .string(_, let stringContext):
+            addStringField(metadata: stringContext, schema: schema,
+                           model: &model, fieldName: enclosingEntityName, modelOverride: modelOverride)
+        case .number(_, let numberContext):
+            model.fieldDescriptions[enclosingEntityName] = Fields.double(rangeConstraint:
+                                                                            NumericRangeConstraint<Double>(minimum: numberContext.minimum?.value,
+                                                                                                           maximum: numberContext.maximum?.value,
+                                                                                                           exclusiveMinimum: numberContext.minimum?.exclusive ?? false,
+                                                                                                           exclusiveMaximum: numberContext.maximum?.exclusive ?? false))
+        case .all(let otherSchema, _), .any(let otherSchema, _), .one(let otherSchema, _):
+            var structureDescription = StructureDescription()
+            parseOtherSchemas(structureDescription: &structureDescription, enclosingEntityName: &enclosingEntityName, model: &model, otherSchema: otherSchema, modelOverride: modelOverride, document: document)
+        case .reference:
+            break
+        case .fragment:
+            fatalError("Schema 'fragment' not implemented")
+        case .not:
+            fatalError("Schema 'not' not implemented")
+        }
+    }
+    
+    static func parseObjectSchema(structureDescription: inout StructureDescription, enclosingEntityName: inout String,
+                                  model: inout OpenAPIServiceModel, objectContext: JSONSchema.ObjectContext,
+                                  modelOverride: ModelOverride?, document: OpenAPI.Document) {
+        let sortedKeys = objectContext.properties.keys.sorted(by: <)
+        
+        for (index, name) in sortedKeys.enumerated() {
+            guard let property = objectContext.properties[name] else {
+                continue
+            }
+            switch property {
+            case .reference(let ref):
+                if let referenceName = ref.name {
+                    structureDescription.members[name] = Member(value: referenceName, position: index,
+                                                                required: objectContext.requiredArray.contains(name),
+                                                                documentation: nil)
+            }
+            default:
+                var enclosingEntityNameForProperty = enclosingEntityName + name.startingWithUppercase
+                parseDefinitionSchemas(model: &model, enclosingEntityName: &enclosingEntityNameForProperty,
+                                       schema: property, modelOverride: modelOverride, document: document)
+                
+                structureDescription.members[name] = Member(value: enclosingEntityNameForProperty, position: index,
+                                                            required: objectContext.requiredArray.contains(name),
+                                                            documentation: nil)
+            }
+        }
+    }
+    
+    static func parseMapDefinitionSchema(mapSchema: JSONSchema,
+                                         enclosingEntityName: inout String,
+                                         model: inout OpenAPIServiceModel) {
+        let valueType: String
+        switch mapSchema {
+        case .reference(let ref):
+            if let valueType = ref.name {
+                model.fieldDescriptions[enclosingEntityName] = Fields.map(
+                    keyType: "String", valueType: valueType,
+                    lengthConstraint: LengthRangeConstraint<Int>())
+            }
+        case .string:
+            valueType = "String"
+            model.fieldDescriptions[enclosingEntityName] = Fields.map(
+                keyType: "String", valueType: valueType,
+                lengthConstraint: LengthRangeConstraint<Int>())
+        default:
+            fatalError("Not implemented")
+        }
+        
+    }
+    
+    static func parseArrayDefinitionSchemas(arrayMetadata: JSONSchema.ArrayContext,
+                                            enclosingEntityName: inout String,
+                                            model: inout OpenAPIServiceModel,
+                                            modelOverride: ModelOverride?, document: OpenAPI.Document) {
+        if let value = arrayMetadata.items {
+            switch value {
+            case .reference(let ref):
+                if let type = ref.name {
+                    // If minItems is 0, the field is optional and does not required validation
+                    if arrayMetadata.minItems == 0 {
+                        let lengthConstraint = LengthRangeConstraint<Int>(minimum: nil,
+                                                                          maximum: arrayMetadata.maxItems)
+                        model.fieldDescriptions[enclosingEntityName] = Fields.list(type: type,
+                                                                                   lengthConstraint: lengthConstraint)
+                    } else {
+                        let lengthConstraint = LengthRangeConstraint<Int>(minimum: arrayMetadata.minItems,
+                                                                          maximum: arrayMetadata.maxItems)
+                        model.fieldDescriptions[enclosingEntityName] = Fields.list(type: type,
+                                                                                   lengthConstraint: lengthConstraint)
+                    }
+                }
+            case .string:
+                var arrayElementEntityName: String
+                
+                // If the enclosingEntityName ends in an "s", swap with element name
+                if enclosingEntityName.suffix(1).lowercased() == "s" {
+                    arrayElementEntityName = String(enclosingEntityName.dropLast())
+                } else {
+                    arrayElementEntityName = enclosingEntityName
+                    enclosingEntityName = "\(enclosingEntityName)s"
+                }
+                
+                parseDefinitionSchemas(model: &model, enclosingEntityName: &arrayElementEntityName,
+                                       schema: value, modelOverride: modelOverride, document: document)
+                
+                let type = arrayElementEntityName
+                
+                // If minItems is 0, the field is optional and does not required validation
+                if arrayMetadata.minItems == 0 {
+                    let lengthConstraint = LengthRangeConstraint<Int>(minimum: nil,
+                                                                      maximum: arrayMetadata.maxItems)
+                    model.fieldDescriptions[enclosingEntityName] = Fields.list(type: type,
+                                                                               lengthConstraint: lengthConstraint)
+                } else {
+                    let lengthConstraint = LengthRangeConstraint<Int>(minimum: arrayMetadata.minItems,
+                                                                      maximum: arrayMetadata.maxItems)
+                    model.fieldDescriptions[enclosingEntityName] = Fields.list(type: type,
+                                                                               lengthConstraint: lengthConstraint)
+                }
+            default:
+                fatalError("Not implemented")
+            }
+        }
+    }
+    
+    // Parse all, any, one schemas
+    static func parseOtherSchemas(structureDescription: inout StructureDescription, enclosingEntityName: inout String,
+                                  model: inout OpenAPIServiceModel, otherSchema: [JSONSchema],
+                                  modelOverride: ModelOverride?, document: OpenAPI.Document) {
+        for (index, subschema) in otherSchema.enumerated() {
+            var enclosingEntityNameForProperty = "\(enclosingEntityName)\(index + 1)"
+            
+            switch subschema {
+            case .object(_, let objectContext):
+                parseObjectSchema(structureDescription: &structureDescription, enclosingEntityName: &enclosingEntityNameForProperty,
+                                  model: &model, objectContext: objectContext, modelOverride: modelOverride, document: document)
+            default:
+                fatalError("Non object/structure allOf schemas are not implemented. \(String(describing: subschema.jsonType))")
+            }
+        }
+    }
+}

--- a/Sources/OpenAPIServiceModel/SetOperationInput.swift
+++ b/Sources/OpenAPIServiceModel/SetOperationInput.swift
@@ -52,8 +52,7 @@ internal extension OpenAPIServiceModel {
             model.structureDescriptions[inputModelName] = structureDefinition
             description.input = inputModelName
             
-            if operationInputFields.pathFields.isEmpty && !operationInputFields.queryFields.isEmpty
-                && operationInputFields.bodyFields.isEmpty && operationInputFields.additionalHeaderFields.isEmpty {
+            if !operationInputFields.queryFields.isEmpty {
                 description.inputDescription = OperationInputDescription(
                     pathFields: operationInputFields.pathFields,
                     queryFields: [],

--- a/Sources/OpenAPIServiceModel/SetOperationInput.swift
+++ b/Sources/OpenAPIServiceModel/SetOperationInput.swift
@@ -1,0 +1,124 @@
+// Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SetOperationInput.swift
+// OpenAPIServiceModel
+//
+
+import Foundation
+import OpenAPIKit
+import ServiceModelEntities
+import ServiceModelCodeGeneration
+import Yams
+
+internal extension OpenAPIServiceModel {
+    struct OperationInputFields {
+        let allMembers: [String: Member]
+        let pathFields: [String]
+        let queryFields: [String]
+        let bodyFields: [String]
+        let additionalHeaderFields: [String]
+    }
+    
+    static func setOperationInput(bodyStructureName: String?,
+                                  operationInputMembers: OperationInputMembers,
+                                  description: inout OperationDescription,
+                                  model: inout OpenAPIServiceModel,
+                                  operationName: String) {
+        if let bodyStructureName = bodyStructureName,
+            operationInputMembers.queryMembers.isEmpty && operationInputMembers.additionalHeaderMembers.isEmpty
+                && operationInputMembers.pathMembers.isEmpty {
+            description.input = bodyStructureName
+        } else {
+            let operationInputFields = getOperationInputFields(bodyStructureName: bodyStructureName,
+                                                               operationInputMembers: operationInputMembers,
+                                                               model: &model)
+            
+            let inputModelName = "\(operationName)Request"
+            let inputModelDescription = "Input model for the \(operationName) operation."
+            let structureDefinition = StructureDescription(members: operationInputFields.allMembers,
+                                                           documentation: inputModelDescription)
+            
+            model.structureDescriptions[inputModelName] = structureDefinition
+            description.input = inputModelName
+            
+            if operationInputFields.pathFields.isEmpty && !operationInputFields.queryFields.isEmpty
+                && operationInputFields.bodyFields.isEmpty && operationInputFields.additionalHeaderFields.isEmpty {
+                description.inputDescription = OperationInputDescription(
+                    pathFields: operationInputFields.pathFields,
+                    queryFields: [],
+                    bodyFields: operationInputFields.bodyFields,
+                    additionalHeaderFields: operationInputFields.additionalHeaderFields,
+                    defaultInputLocation: .query,
+                    bodyStructureName: bodyStructureName)
+            } else {
+                description.inputDescription = OperationInputDescription(
+                    pathFields: operationInputFields.pathFields,
+                    queryFields: operationInputFields.queryFields,
+                    bodyFields: operationInputFields.bodyFields,
+                    additionalHeaderFields: operationInputFields.additionalHeaderFields,
+                    defaultInputLocation: .body,
+                    bodyStructureName: bodyStructureName)
+            }
+        }
+    }
+    
+    static func getOperationInputFields(bodyStructureName: String?,
+                                        operationInputMembers: OperationInputMembers,
+                                        model: inout OpenAPIServiceModel) -> OperationInputFields {
+        var allMembers: [String: Member] = [:]
+        let pathFields: [String]
+        let queryFields: [String]
+        let bodyFields: [String]
+        let additionalHeaderFields: [String]
+        
+        if let bodyStructureName = bodyStructureName {
+                guard let structureDefinition = model.structureDescriptions[bodyStructureName] else {
+                    fatalError("No structure with type \(bodyStructureName)")
+                }
+    
+                allMembers.merge(structureDefinition.members) { (old, _) in old }
+                bodyFields = [String](structureDefinition.members.keys)
+            } else {
+                bodyFields = []
+            }
+    
+            allMembers.merge(operationInputMembers.queryMembers) { (old, _) in old }
+            queryFields = [String](operationInputMembers.queryMembers.keys)
+    
+            allMembers.merge(operationInputMembers.additionalHeaderMembers) { (old, _) in old }
+            additionalHeaderFields = [String](operationInputMembers.additionalHeaderMembers.keys)
+    
+            allMembers.merge(operationInputMembers.pathMembers) { (old, _) in old }
+            pathFields = [String](operationInputMembers.pathMembers.keys)
+    
+            let sortedMembers = allMembers.sorted { (left, right) in left.key < right.key }
+            var correctedAllMembers: [String: Member] = [:]
+            sortedMembers.enumerated().forEach { entry in
+                let oldMember = entry.element.value
+                let correctedMember = Member(value: oldMember.value,
+                                             position: entry.offset,
+                                             locationName: oldMember.locationName,
+                                             required: oldMember.required,
+                                             documentation: oldMember.documentation)
+    
+                correctedAllMembers[entry.element.key] = correctedMember
+            }
+        
+        return OperationInputFields(allMembers: correctedAllMembers,
+                                    pathFields: pathFields,
+                                    queryFields: queryFields,
+                                    bodyFields: bodyFields,
+                                    additionalHeaderFields: additionalHeaderFields)
+    }
+}

--- a/Sources/OpenAPIServiceModel/SetOperationOutput.swift
+++ b/Sources/OpenAPIServiceModel/SetOperationOutput.swift
@@ -1,0 +1,171 @@
+// Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// SetOperationOutput.swift
+// OpenAPIServiceModel
+//
+
+import Foundation
+import OpenAPIKit
+import ServiceModelEntities
+import ServiceModelCodeGeneration
+import Yams
+
+internal extension OpenAPIServiceModel {
+    static func filterHeaders(operation: OpenAPI.Operation, code: Int, headers: OpenAPI.Header.Map,
+                              modelOverride: ModelOverride?) -> OpenAPI.Header.Map {
+        
+        guard let ignoreResponseHeaders = modelOverride?.ignoreResponseHeaders else {
+            return headers
+        }
+        
+        var filteredHeaders: OpenAPI.Header.Map = [:]
+        
+        headers.forEach { (key, value) in
+            if ignoreResponseHeaders.contains("*.*.*") {
+                return
+            }
+            
+            if ignoreResponseHeaders.contains("*.*.\(key)") {
+                return
+            }
+            
+            if ignoreResponseHeaders.contains("*.\(code).*") {
+                return
+            }
+            
+            if let identifier = operation.operationId {
+                if ignoreResponseHeaders.contains("\(identifier).\(code).\(key)") {
+                    return
+                }
+                
+                if ignoreResponseHeaders.contains("\(identifier).*.\(key)") {
+                    return
+                }
+                
+                if ignoreResponseHeaders.contains("\(identifier).\(code).*") {
+                    return
+                }
+            }
+            
+            filteredHeaders[key] = value
+        }
+        
+        return filteredHeaders
+    }
+    
+    static func setOperationOutput(operation: OpenAPI.Operation, operationName: String, model: inout OpenAPIServiceModel,
+                                   modelOverride: ModelOverride?, description: inout OperationDescription, document: OpenAPI.Document) {
+        for (code, response) in operation.responses {
+            switch response {
+            case .b(let value):
+                switch code {
+                case .status(let code):
+                    if let headers = value.headers {
+                        let filteredHeaders = filterHeaders(operation: operation, code: code,
+                                                            headers: headers, modelOverride: modelOverride)
+                        
+                        var headerMembers: [String: Member] = [:]
+                        
+                        filteredHeaders.enumerated().forEach { entry in
+                            let typeName = entry.element.key.safeModelName().startingWithUppercase
+                            
+                            let headerName = "\(operationName)\(typeName)Header"
+                            
+                            if let header = entry.element.value.b  {
+                                if let schema = header.schemaOrContent.schemaValue {
+                                    addField(item: schema, fieldName: headerName, model: &model, modelOverride: modelOverride)
+                                    let member = Member(value: headerName,
+                                                        position: entry.offset,
+                                                        required: false,
+                                                        documentation: header.description)
+                                    headerMembers[entry.element.key] = member
+                                }
+                            }
+                        }
+                        
+                        let content = value.content
+                            content.enumerated().forEach { entry in
+                            if let schema = entry.element.value.schema?.b {
+                                addOperationResponseFromSchema(schema: schema, operationName: operationName, forCode: code, index: nil,
+                                                               description: &description, model: &model, modelOverride: modelOverride, document: document)
+                            } else if let ref = entry.element.value.schema?.a {
+                                addOperationResponseFromReference(reference: ref, operationName: operationName, forCode: code, index: nil,
+                                                                  description: &description, model: &model, modelOverride: modelOverride)
+                            }
+                        }
+                        
+                        if !headerMembers.isEmpty {
+                            setOperationOutputWithHeaders(description: &description, model: &model, headerMembers: headerMembers,
+                                                          operationName: operationName, code: code)
+                        }
+                        
+                    }
+                default:
+                    fatalError("Range and Default status code types not implemented.")
+                }
+            case .a:
+                fatalError("Not implemented.")
+            }
+        }
+    }
+    
+    private static func setOperationOutputWithHeaders(description: inout OperationDescription, model: inout OpenAPIServiceModel,
+                                                      headerMembers: [String: Member], operationName: String, code: Int) {
+        var allMembers: [String: Member] = [:]
+        let bodyFields: [String]
+        let headerFields: [String]
+        let bodyStructureName = description.output
+        
+        if let bodyStructureName = bodyStructureName {
+            guard let structureDefinition = model.structureDescriptions[bodyStructureName] else {
+                fatalError("No structure with type \(bodyStructureName)")
+            }
+            
+            allMembers.merge(structureDefinition.members) { (old, _) in old }
+            bodyFields = [String](structureDefinition.members.keys)
+        } else {
+            bodyFields = []
+        }
+        
+        allMembers.merge(headerMembers) { (old, _) in old }
+        headerFields = [String](headerMembers.keys)
+        
+        let sortedMembers = allMembers.sorted { (left, right) in left.key < right.key }
+        var correctedAllMembers: [String: Member] = [:]
+        sortedMembers.enumerated().forEach { entry in
+            let oldMember = entry.element.value
+            let correctedMember = Member(value: oldMember.value,
+                                         position: entry.offset,
+                                         locationName: oldMember.locationName,
+                                         required: oldMember.required,
+                                         documentation: oldMember.documentation)
+            
+            correctedAllMembers[entry.element.key] = correctedMember
+        }
+        
+        let outputModelName = "\(operationName)\(code)Response"
+        let outputModelDescription = "Output model for the \(operationName) operation."
+        let structureDefinition = StructureDescription(members: correctedAllMembers,
+                                                       documentation: outputModelDescription)
+        
+        model.structureDescriptions[outputModelName] = structureDefinition
+        description.output = outputModelName
+        
+        description.outputDescription = OperationOutputDescription(
+            bodyFields: bodyFields,
+            headerFields: headerFields,
+            bodyStructureName: bodyStructureName,
+            payloadAsMember: nil)
+    }
+}


### PR DESCRIPTION
Create the OpenAPIServiceModel using OpenAPIKit to generate OpenAPI 3.0 compliant service models.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
