### PR TITLE
Extend service model generation for errors and operations

### DIFF
--- a/Sources/ServiceModelCodeGeneration/ModelErrorsDelegate.swift
+++ b/Sources/ServiceModelCodeGeneration/ModelErrorsDelegate.swift
@@ -123,6 +123,40 @@ public protocol ModelErrorsDelegate {
         */
        func errorTypeAdditionalDescriptionCases(fileBuilder: FileBuilder,
                                                 errorTypes: [ErrorType])
+
+    /**
+        Generator for the error type additional option set items.
+    
+        - Parameters:
+           - fileBuilder: The FileBuilder to output to.
+           - optionSetTypeName: The name of the option set structure.
+           - errorTypes: The sorted list of error types.
+        */
+    func errorTypeAdditionalOptionSetItems(fileBuilder: FileBuilder,
+                                           optionSetTypeName: String,
+                                           errorTypes: [ErrorType])
+    
+    /**
+        Generator for the error type additional option set item descriptions.
+    
+        - Parameters:
+           - fileBuilder: The FileBuilder to output to.
+           - errorTypes: The sorted list of error types.
+        */
+    func errorTypeAdditionalOptionSetItemDescriptions(fileBuilder: FileBuilder,
+                                                      errorTypes: [ErrorType])
+    
+    /**
+        Generator for the error type additional error handling extensions.
+    
+        - Parameters:
+           - fileBuilder: The FileBuilder to output to.
+           - errorTypes: The sorted list of error types.
+           - baseName: The base name for the model.
+        */
+    func errorTypeAdditionalExtensions(fileBuilder: FileBuilder,
+                                       errorTypes: [ErrorType],
+                                       baseName: String)
 }
 
 public extension ModelErrorsDelegate {
@@ -133,6 +167,23 @@ public extension ModelErrorsDelegate {
         default:
             return "CustomStringConvertible"
         }
+    }
+
+    func errorTypeAdditionalOptionSetItems(fileBuilder: FileBuilder,
+                                           optionSetTypeName: String,
+                                           errorTypes: [ErrorType]) {
+        // default implementation, do nothing
+    }
+    
+    func errorTypeAdditionalOptionSetItemDescriptions(fileBuilder: FileBuilder,
+                                                      errorTypes: [ErrorType]) {
+        // default implementation, do nothing
+    }
+    
+    func errorTypeAdditionalExtensions(fileBuilder: FileBuilder,
+                                       errorTypes: [ErrorType],
+                                       baseName: String) {
+        // default implementation, do nothing
     }
 }
 

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelErrors.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelErrors.swift
@@ -224,6 +224,10 @@ public extension ServiceModelCodeGenerator {
             fileBuilder.appendLine("    public static let \(internalName) = \(baseName)ErrorTypes(rawValue: \(index + 1))")
         }
         
+        delegate.errorTypeAdditionalOptionSetItems(fileBuilder: fileBuilder,
+                                                   optionSetTypeName: "\(baseName)ErrorTypes",
+                                                   errorTypes: sortedErrors)
+
         fileBuilder.appendLine("""
             }
             
@@ -242,6 +246,7 @@ public extension ServiceModelCodeGenerator {
                     return \(internalName)Identity
                 """)
         }
+        delegate.errorTypeAdditionalOptionSetItemDescriptions(fileBuilder: fileBuilder, errorTypes: sortedErrors)
         fileBuilder.decIndent()
         fileBuilder.decIndent()
         

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelOperationsEnum.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelOperationsEnum.swift
@@ -67,9 +67,8 @@ public extension ServiceModelCodeGenerator {
         
         fileBuilder.appendEmptyLine()
         addOperationPathEnum(fileBuilder, sortedOperations)
-        fileBuilder.appendLine("""
-            }
-            """)
+        fileBuilder.appendEmptyLine()
+        addAllowedErrors(sortedOperations: sortedOperations, fileBuilder: fileBuilder, baseName: baseName)
         
         fileBuilder.decIndent()
         fileBuilder.appendLine("}")
@@ -128,6 +127,35 @@ public extension ServiceModelCodeGenerator {
         
         fileBuilder.appendLine("""
                 }
+            """)
+    }
+
+    private func addAllowedErrors(sortedOperations: [(key: String, value: OperationDescription)],
+                                  fileBuilder: FileBuilder,
+                                  baseName: String) {
+        fileBuilder.appendLine("""
+            public var allowedErrors: [\(baseName)ErrorTypes] {
+                switch self {
+            """)
+            
+        fileBuilder.incIndent()
+        // for each of the operations
+        for (name, operation) in sortedOperations {
+            // convert to lower camel case
+            let internalName = name.upperToLowerCamelCase
+            
+            let sortedErrorNames = operation.errors.map { "." + $0.type.normalizedErrorName }.sorted()
+            let errorList = sortedErrorNames.joined(separator: ", ")
+            fileBuilder.appendLine("""
+                case .\(internalName):
+                    return [\(errorList)]
+                """)
+        }
+        fileBuilder.decIndent()
+        
+        fileBuilder.appendLine("""
+                }
+            }
             """)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add extension points in the `ModelErrorsDelegate` protocol.
- Codegen the list of allowed errors for model operations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
