### PR TITLE
Support async APIs on older Apple OSs.

### DIFF
--- a/Sources/ServiceModelGenerate/ClientProtocolDelegate.swift
+++ b/Sources/ServiceModelGenerate/ClientProtocolDelegate.swift
@@ -80,7 +80,7 @@ public struct ClientProtocolDelegate: ModelClientDelegate {
                                            operationDescription: operationDescription,
                                            delegate: delegate, operationInvokeType: .asyncFunction,
                                            forTypeAlias: true, isGenerator: isGenerator,
-                                           prefixLine: (index == 0) ? "#if compiler(>=5.5) && canImport(_Concurrency)" : nil,
+                                           prefixLine: (index == 0) ? asyncAwaitCondition : nil,
                                            postfixLine: (index == sortedOperations.count - 1) ? "#else" : nil)
             }
             

--- a/Sources/ServiceModelGenerate/MockClientDelegate.swift
+++ b/Sources/ServiceModelGenerate/MockClientDelegate.swift
@@ -282,8 +282,7 @@ public struct MockClientDelegate: ModelClientDelegate {
         fileBuilder.incIndent()
         
         if case .enabled = self.asyncAwaitAPIs, invokeType == .eventLoopFutureAsync {
-            fileBuilder.appendLine("#if compiler(>=5.5) && canImport(_Concurrency)", postInc: true)
-            fileBuilder.appendLine("if #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) {", postInc: true)
+            fileBuilder.appendLine(asyncAwaitCondition, postInc: true)
             
             delegateMockImplementationCall(codeGenerator: codeGenerator,
                                            functionPrefix: functionPrefix,
@@ -292,9 +291,6 @@ public struct MockClientDelegate: ModelClientDelegate {
                                            hasInput: hasInput,
                                            functionOutputType: functionOutputType,
                                            operationName: operationName)
-            fileBuilder.appendLine("} else {", preDec: true, postInc: true)
-            fileBuilder.appendLine("fatalError( \"Swift >=5.5 unsupported below (macOS 12, iOS 15, tvOS 15, watchOS 8)\")")
-            fileBuilder.appendLine("}", preDec: true)
             fileBuilder.appendLine("#else", preDec: true, postInc: true)
             
             delegateMockImplementationCall(codeGenerator: codeGenerator,
@@ -383,8 +379,7 @@ public struct MockClientDelegate: ModelClientDelegate {
         fileBuilder.incIndent()
         
         if case .enabled = self.asyncAwaitAPIs, invokeType == .eventLoopFutureAsync {
-            fileBuilder.appendLine("#if compiler(>=5.5) && canImport(_Concurrency)", postInc: true)
-            fileBuilder.appendLine("if #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) {", postInc: true)
+            fileBuilder.appendLine(asyncAwaitCondition, postInc: true)
             
             delegateMockThrowingImplementationCall(codeGenerator: codeGenerator,
                                                    functionPrefix: functionPrefix,
@@ -393,9 +388,6 @@ public struct MockClientDelegate: ModelClientDelegate {
                                                    hasInput: hasInput,
                                                    functionOutputType: functionOutputType,
                                                    operationName: operationName)
-            fileBuilder.appendLine("} else {", preDec: true, postInc: true)
-            fileBuilder.appendLine("fatalError( \"Swift >=5.5 unsupported below (macOS 12, iOS 15, tvOS 15, watchOS 8)\")")
-            fileBuilder.appendLine("}", preDec: true)
             fileBuilder.appendLine("#else", preDec: true, postInc: true)
             
             delegateMockThrowingImplementationCall(codeGenerator: codeGenerator,

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateClient.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateClient.swift
@@ -19,6 +19,8 @@ import Foundation
 import ServiceModelCodeGeneration
 import ServiceModelEntities
 
+internal let asyncAwaitCondition = "#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)"
+
 public extension ServiceModelCodeGenerator {
     private struct OperationSignature {
         let input: String
@@ -118,7 +120,7 @@ public extension ServiceModelCodeGenerator {
                                  operationDescription: operationDescription,
                                  delegate: delegate, operationInvokeType: .asyncFunction,
                                  forTypeAlias: false, isGenerator: isGenerator,
-                                 prefixLine: (index == 0) ? "#if compiler(>=5.5) && canImport(_Concurrency)" : nil,
+                                 prefixLine: (index == 0) ? asyncAwaitCondition : nil,
                                  postfixLine: (index == sortedOperations.count - 1) ? "#endif" : nil)
                 }
             }
@@ -293,9 +295,6 @@ public extension ServiceModelCodeGenerator {
         if !forTypeAlias {
             fileBuilder.appendLine(" */")
             
-            if case .asyncFunction = invokeType {
-                fileBuilder.appendLine("@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)")
-            }
             functionName = name.upperToLowerCamelCase
         } else {
             functionName = name.getNormalizedTypeName(forModel: model)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Remove `@available` annotation from async APIs, increase the requirement for non Linux platforms to the upcoming 5.5.2 (which will backport async support to the earlier Apple OSs).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
