### PR TITLE
Move to using mattpolzin/OpenAPIKit

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "OpenAPIKit",
-        "repositoryURL": "https://github.com/mndzup/OpenAPIKit.git",
+        "repositoryURL": "https://github.com/mattpolzin/OpenAPIKit.git",
         "state": {
-          "branch": "main",
-          "revision": "fc227db5879429e0f8b8245878689c43212542ca",
-          "version": null
+          "branch": null,
+          "revision": "0c668112f9803c1858ed070f9e8ce84922a0b41f",
+          "version": "3.0.0-alpha.4"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/tachyonics/SwaggerParser.git", from: "0.6.4"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0"),
-        .package(url: "https://github.com/mndzup/OpenAPIKit.git", .branch("main")),
+        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "3.0.0-alpha.4"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -59,7 +59,7 @@ let package = Package(
                 .target(name: "ServiceModelCodeGeneration"),
                 .product(name: "Yams", package: "Yams"),
                 .product(name: "SwaggerParser", package: "SwaggerParser"),
-                .product(name: "OpenAPIKit" , package: "OpenAPIKit"),
+                .product(name: "OpenAPIKit30" , package: "OpenAPIKit"),
             ]
         ),
         .target(

--- a/Sources/OpenAPIServiceModel/CreateOpenAPIServiceModel.swift
+++ b/Sources/OpenAPIServiceModel/CreateOpenAPIServiceModel.swift
@@ -16,7 +16,7 @@
 //
 
 import Foundation
-import OpenAPIKit
+import OpenAPIKit30
 import ServiceModelEntities
 import ServiceModelCodeGeneration
 import Yams
@@ -247,11 +247,11 @@ internal extension OpenAPIServiceModel {
     static func addOperationResponseFromSchema(schema: JSONSchema, operationName: String, forCode code: Int, index: Int?,
                                                description: inout OperationDescription,
                                                model: inout OpenAPIServiceModel, modelOverride: ModelOverride?, document: OpenAPI.Document) {
-        switch schema {
+        switch schema.value {
         case .one(let subschemas, _):
             for (index, subschema) in subschemas.enumerated() {
-                switch subschema {
-                case .reference(let ref):
+                switch subschema.value {
+                case .reference(let ref, _):
                     addOperationResponseFromReference(reference: ref, operationName: operationName, forCode: code,
                                                       index: index, description: &description,
                                                       model: &model, modelOverride: modelOverride)
@@ -299,7 +299,7 @@ internal extension OpenAPIServiceModel {
     
     static func addField(item: JSONSchema, fieldName: String,
                          model: inout OpenAPIServiceModel, modelOverride: ModelOverride?) {
-        switch item {
+        switch item.value {
         case .string(_, let context):
             addStringField(metadata: context,
                            schema: nil,

--- a/Sources/OpenAPIServiceModel/CreateOpenAPIServiceModel.swift
+++ b/Sources/OpenAPIServiceModel/CreateOpenAPIServiceModel.swift
@@ -84,8 +84,16 @@ internal extension OpenAPIServiceModel {
                                                       modelOverride: modelOverride)
             
             for (type, operation) in filteredOperations {
-                guard let operationName = operation.operationId else {
+                guard let operationId = operation.operationId else {
                     continue
+                }
+                
+                // if there is more than one operation for this path
+                let operationName: String
+                if filteredOperations.count > 1 {
+                    operationName = operationId + type.rawValue.lowercased().startingWithUppercase
+                } else {
+                    operationName = operationId
                 }
                 
                 let inputDescription =
@@ -136,11 +144,14 @@ internal extension OpenAPIServiceModel {
         var members = OperationInputMembers()
         var bodyStructureName: String?
         
-        if let requestBody = operation.requestBody?.b {
-            getBodyOperationMembers(requestBody, bodyStructureName: &bodyStructureName,
-                                    operationName: operationName, model: &model, modelOverride: modelOverride, document: document)
-        } else {
-            fatalError("no request body")
+        if let requestBody = operation.requestBody {
+            switch requestBody {
+            case .a:
+                fatalError("Unsupported request body reference.")
+            case .b(let request):
+                getBodyOperationMembers(request, bodyStructureName: &bodyStructureName,
+                                        operationName: operationName, model: &model, modelOverride: modelOverride, document: document)
+            }
         }
         
         for (index, parameter) in operation.parameters.enumerated() {
@@ -163,27 +174,30 @@ internal extension OpenAPIServiceModel {
                                         operationName: String, model: inout OpenAPIServiceModel,
                                         modelOverride: ModelOverride?, document: OpenAPI.Document) {
         for (_, content) in request.content {
-            if let schema = content.schema?.b {
-                switch schema {
-                case .object:
-                    var enclosingEntityName = "\(operationName)RequestBody"
-                    var structureDescription = StructureDescription()
-                    guard let objectContext = schema.objectContext else {
-                       continue
+            if let either = content.schema {
+                switch either {
+                case .a(let reference):
+                    if let refName = reference.name {
+                        bodyStructureName = refName
                     }
-                    parseObjectSchema(structureDescription: &structureDescription, enclosingEntityName: &enclosingEntityName,
-                                      model: &model, objectContext: objectContext, modelOverride: modelOverride, document: document)
-                    
-                    model.structureDescriptions[enclosingEntityName] = structureDescription
-                    
-                    bodyStructureName = enclosingEntityName
-                default:
-                    // The schemas object and reference are most widely used in the requestBody field
-                    fatalError("Not implemented.")
-                }
-            } else if let reference = content.schema?.a {
-                if let refName = reference.name {
-                    bodyStructureName = refName
+                case .b(let schema):
+                    switch schema.value {
+                    case .object:
+                        var enclosingEntityName = "\(operationName)RequestBody"
+                        var structureDescription = StructureDescription()
+                        guard let objectContext = schema.objectContext else {
+                           continue
+                        }
+                        parseObjectSchema(structureDescription: &structureDescription, enclosingEntityName: &enclosingEntityName,
+                                          model: &model, objectContext: objectContext, modelOverride: modelOverride, document: document)
+                        
+                        model.structureDescriptions[enclosingEntityName] = structureDescription
+                        
+                        bodyStructureName = enclosingEntityName
+                    default:
+                        // The schemas object and reference are most widely used in the requestBody field
+                        fatalError("Not implemented.")
+                    }
                 }
             }
         }

--- a/Sources/OpenAPIServiceModel/OpenAPIServiceModel.swift
+++ b/Sources/OpenAPIServiceModel/OpenAPIServiceModel.swift
@@ -16,7 +16,7 @@
 //
 
 import Foundation
-import OpenAPIKit
+import OpenAPIKit30
 import ServiceModelEntities
 import ServiceModelCodeGeneration
 import Yams

--- a/Sources/OpenAPIServiceModel/ParseSchemas.swift
+++ b/Sources/OpenAPIServiceModel/ParseSchemas.swift
@@ -136,7 +136,14 @@ internal extension OpenAPIServiceModel {
             switch items.value {
             case .reference(let ref, _):
                 if let type = ref.name {
-                    let lengthConstraint = LengthRangeConstraint<Int>(minimum: arrayMetadata.minItems,
+                    let optionalMinItems: Int?
+                    if arrayMetadata.minItems > 0 {
+                        optionalMinItems = arrayMetadata.minItems
+                    } else {
+                        optionalMinItems = nil
+                    }
+                    
+                    let lengthConstraint = LengthRangeConstraint<Int>(minimum: optionalMinItems,
                                                                       maximum: arrayMetadata.maxItems)
                     model.fieldDescriptions[enclosingEntityName] = Fields.list(type: type,
                                                                                lengthConstraint: lengthConstraint)
@@ -157,7 +164,14 @@ internal extension OpenAPIServiceModel {
                 
                 let type = arrayElementEntityName
                 
-                let lengthConstraint = LengthRangeConstraint<Int>(minimum: arrayMetadata.minItems,
+                let optionalMinItems: Int?
+                if arrayMetadata.minItems > 0 {
+                    optionalMinItems = arrayMetadata.minItems
+                } else {
+                    optionalMinItems = nil
+                }
+                
+                let lengthConstraint = LengthRangeConstraint<Int>(minimum: optionalMinItems,
                                                                   maximum: arrayMetadata.maxItems)
                 model.fieldDescriptions[enclosingEntityName] = Fields.list(type: type,
                                                                            lengthConstraint: lengthConstraint)

--- a/Sources/OpenAPIServiceModel/SetOperationInput.swift
+++ b/Sources/OpenAPIServiceModel/SetOperationInput.swift
@@ -16,7 +16,7 @@
 //
 
 import Foundation
-import OpenAPIKit
+import OpenAPIKit30
 import ServiceModelEntities
 import ServiceModelCodeGeneration
 import Yams

--- a/Sources/OpenAPIServiceModel/SetOperationOutput.swift
+++ b/Sources/OpenAPIServiceModel/SetOperationOutput.swift
@@ -16,7 +16,7 @@
 //
 
 import Foundation
-import OpenAPIKit
+import OpenAPIKit30
 import ServiceModelEntities
 import ServiceModelCodeGeneration
 import Yams
@@ -69,7 +69,7 @@ internal extension OpenAPIServiceModel {
         for (code, response) in operation.responses {
             switch response {
             case .b(let value):
-                switch code {
+                switch code.value {
                 case .status(let code):
                     var headerMembers: [String: Member] = [:]
 

--- a/Sources/OpenAPIServiceModel/SetOperationOutput.swift
+++ b/Sources/OpenAPIServiceModel/SetOperationOutput.swift
@@ -96,12 +96,17 @@ internal extension OpenAPIServiceModel {
                     
                     let content = value.content
                     content.enumerated().forEach { entry in
-                    if let schema = entry.element.value.schema?.b {
-                        addOperationResponseFromSchema(schema: schema, operationName: operationName, forCode: code, index: nil,
-                                                       description: &description, model: &model, modelOverride: modelOverride, document: document)
-                    } else if let ref = entry.element.value.schema?.a {
-                        addOperationResponseFromReference(reference: ref, operationName: operationName, forCode: code, index: nil,
-                                                          description: &description, model: &model, modelOverride: modelOverride)
+                        if let either = entry.element.value.schema {
+                            switch either {
+                            case .a(let ref):
+                                addOperationResponseFromReference(reference: ref, operationName: operationName, forCode: code,
+                                                                  index: nil, description: &description, model: &model,
+                                                                  modelOverride: modelOverride)
+                            case .b(let schema):
+                                addOperationResponseFromSchema(schema: schema, operationName: operationName, forCode: code,
+                                                               index: nil, description: &description, model: &model,
+                                                               modelOverride: modelOverride, document: document)
+                            }
                         }
                     }
                         


### PR DESCRIPTION
*Issue #, if available:*
1. Move to using mattpolzin/OpenAPIKit for OpenAPI 3.0 support.
2. Some fixes to ensure the same code is generated for https://github.com/amzn/smoke-framework-examples/tree/main/EmptyExampleService

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
