### PR TITLE
Add service information to the service model.

### DIFF
--- a/Sources/OpenAPIServiceModel/CreateOpenAPIServiceModel.swift
+++ b/Sources/OpenAPIServiceModel/CreateOpenAPIServiceModel.swift
@@ -67,6 +67,11 @@ internal extension OpenAPIServiceModel {
     static func createOpenAPIModel(definition: OpenAPI.Document, modelOverride: ModelOverride?) -> OpenAPIServiceModel {
         var model = OpenAPIServiceModel()
 
+        model.serviceInformation = ServiceInformation(
+            title: definition.info.title,
+            description: definition.info.description,
+            version: definition.info.version)
+
         for (name, schema) in definition.components.schemas {
             var enclosingEntityName = name.rawValue
             parseDefinitionSchemas(model: &model, enclosingEntityName: &enclosingEntityName,

--- a/Sources/OpenAPIServiceModel/OpenAPIServiceModel.swift
+++ b/Sources/OpenAPIServiceModel/OpenAPIServiceModel.swift
@@ -25,6 +25,7 @@ import Yams
  Struct that models the Metadata of the OpenAPI  model.
  */
 public struct OpenAPIServiceModel: ServiceModel {
+    public var serviceInformation: ServiceInformation? = nil
     public var serviceDescriptions: [String: ServiceDescription] = [:]
     public var structureDescriptions: [String: StructureDescription] = [:]
     public var operationDescriptions: [String: OperationDescription] = [:]

--- a/Sources/ServiceModelEntities/ModelEntities.swift
+++ b/Sources/ServiceModelEntities/ModelEntities.swift
@@ -18,6 +18,21 @@
 import Foundation
 
 /**
+ Metadata about the servide.
+ */
+public struct ServiceInformation {
+    public let title: String
+    public let description: String?
+    public let version: String
+
+    public init (title: String, description: String?, version: String) {
+        self.title = title
+        self.description = description
+        self.version = version
+    }
+}
+
+/**
  Description of a service in the model.
  */
 public struct ServiceDescription {

--- a/Sources/ServiceModelEntities/ServiceModel.swift
+++ b/Sources/ServiceModelEntities/ServiceModel.swift
@@ -31,6 +31,7 @@ public enum ServiceModelError: Error {
  Protocol for a Service Model description.
  */
 public protocol ServiceModel {
+    var serviceInformation: ServiceInformation? { get }
     var serviceDescriptions: [String: ServiceDescription] { get }
     var structureDescriptions: [String: StructureDescription] { get }
     var operationDescriptions: [String: OperationDescription] { get }
@@ -53,6 +54,9 @@ public protocol ServiceModel {
 }
 
 public extension ServiceModel {
+    // Provide default value for backwards compatibility
+    var serviceInformation: ServiceInformation? { nil }
+
     static func create(dataList: [Data], modelFormat: ModelFormat, modelOverride: ModelOverride?) throws -> Self {
         throw ServiceModelError.notImplementedException
     }

--- a/Sources/SwaggerServiceModel/SwaggerServiceModel+createSwaggerModel.swift
+++ b/Sources/SwaggerServiceModel/SwaggerServiceModel+createSwaggerModel.swift
@@ -65,6 +65,11 @@ internal extension SwaggerServiceModel {
     
     static func createSwaggerModel(definition: Swagger, modelOverride: ModelOverride?) -> SwaggerServiceModel {
         var model = SwaggerServiceModel()
+
+        model.serviceInformation = ServiceInformation(
+            title: definition.information.title,
+            description: definition.information.description,
+            version: definition.information.version)
         
         for (name, schema) in definition.definitions {
             var enclosingEntityName = name

--- a/Sources/SwaggerServiceModel/SwaggerServiceModel.swift
+++ b/Sources/SwaggerServiceModel/SwaggerServiceModel.swift
@@ -26,6 +26,7 @@ import Yams
  */
 public struct SwaggerServiceModel: ServiceModel {
     var documentationDescriptions: [String: String] = [:]
+    public var serviceInformation: ServiceInformation? = nil
     public var serviceDescriptions: [String: ServiceDescription] = [:]
     public var structureDescriptions: [String: StructureDescription] = [:]
     public var operationDescriptions: [String: OperationDescription] = [:]


### PR DESCRIPTION
*Description of changes:*
Add service information to the service model. The information includes service title, service description and service version. This information is parsed from the `info` section of the Swagger or OpenAPI specification.

The changes are backwards compatible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
