### PR TITLE
Update enumeration declaration to conform to CaseIterable

### DIFF
--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateEnumerationDeclaration.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateEnumerationDeclaration.swift
@@ -40,7 +40,7 @@ extension ServiceModelCodeGenerator {
         
         fileBuilder.appendLine(" Enumeration restricting the values of the \(typeName) field.")
         fileBuilder.appendLine(" */")
-        fileBuilder.appendLine("public enum \(typeName): String, Codable, CustomStringConvertible {", postInc: true)
+        fileBuilder.appendLine("public enum \(typeName): String, Codable, CustomStringConvertible, CaseIterable {", postInc: true)
         
         let sortedValues = valueConstraints.sorted { (left, right) in left.name < right.name }
         // iterate through the values


### PR DESCRIPTION
Issue #50

This PR updates enum declaration to conform to CaseIterable. (https://developer.apple.com/documentation/swift/caseiterable)

This makes it more convenient to write tests that need to cover all enum cases.

This also helps in a rare situation when all enum cases need to be converted to a different value (e.g. put into a Set).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

