### PR TITLE
Add compiler options.

### DIFF
--- a/Sources/ServiceModelCodeGeneration/CodeGenerationCustomizations.swift
+++ b/Sources/ServiceModelCodeGeneration/CodeGenerationCustomizations.swift
@@ -18,6 +18,12 @@
 import Foundation
 import ServiceModelEntities
 
+public enum MinimumCompilerSupport: String, Codable {
+    case unknown = "UNKNOWN"
+    case v5_6 = "5.6"
+    case v5_7 = "5.7"
+}
+
 /**
  Specifies customizations to the code generation.
  */
@@ -37,10 +43,16 @@ public struct CodeGenerationCustomizations {
     public let httpClientConfiguration: HttpClientConfiguration
     /// If async/await APIs should be included
     public let asyncAwaitAPIs: CodeGenFeatureStatus
+    public let addSendableConformance: CodeGenFeatureStatus
+    public let eventLoopFutureClientAPIs: CodeGenFeatureStatus
+    public let minimumCompilerSupport: MinimumCompilerSupport
     
     public init(validationErrorDeclaration: ErrorDeclaration,
                 unrecognizedErrorDeclaration: ErrorDeclaration,
                 asyncAwaitAPIs: CodeGenFeatureStatus,
+                eventLoopFutureClientAPIs: CodeGenFeatureStatus = .enabled,
+                addSendableConformance: CodeGenFeatureStatus = .disabled,
+                minimumCompilerSupport: MinimumCompilerSupport = .unknown,
                 generateModelShapeConversions: Bool,
                 optionalsInitializeEmpty: Bool,
                 fileHeader: String?,
@@ -48,6 +60,9 @@ public struct CodeGenerationCustomizations {
         self.validationErrorDeclaration = validationErrorDeclaration
         self.unrecognizedErrorDeclaration = unrecognizedErrorDeclaration
         self.generateModelShapeConversions = generateModelShapeConversions
+        self.eventLoopFutureClientAPIs = eventLoopFutureClientAPIs
+        self.addSendableConformance = addSendableConformance
+        self.minimumCompilerSupport = minimumCompilerSupport
         self.optionalsInitializeEmpty = optionalsInitializeEmpty
         self.fileHeader = fileHeader
         self.httpClientConfiguration = httpClientConfiguration

--- a/Sources/ServiceModelCodeGeneration/ModelClientDelegate.swift
+++ b/Sources/ServiceModelCodeGeneration/ModelClientDelegate.swift
@@ -32,6 +32,8 @@ public protocol ModelClientDelegate {
     var clientType: ClientType { get }
 
     var asyncAwaitAPIs: CodeGenFeatureStatus { get }
+    var eventLoopFutureClientAPIs: CodeGenFeatureStatus { get }
+    var minimumCompilerSupport: MinimumCompilerSupport { get }
         
     /**
      Add any custom file headers to the client file.
@@ -115,6 +117,14 @@ public enum InvokeType: String {
 }
 
 public extension ModelClientDelegate {
+    var eventLoopFutureClientAPIs: CodeGenFeatureStatus {
+        return .enabled
+    }
+    
+    var minimumCompilerSupport: MinimumCompilerSupport {
+        return .unknown
+    }
+    
     func getHttpClientForOperation(name: String, httpClientConfiguration: HttpClientConfiguration?) -> String {
         if let additionalClients = httpClientConfiguration?.additionalClients {
             for (key, value) in additionalClients {

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateEnumerationDeclaration.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateEnumerationDeclaration.swift
@@ -38,9 +38,15 @@ extension ServiceModelCodeGenerator {
         fileBuilder.appendEmptyLine()
         fileBuilder.appendLine("/**")
         
+        var conformingProtocols: [String] = ["String", "Codable", "CustomStringConvertible", "CaseIterable"]
+        if case .enabled = self.customizations.addSendableConformance {
+            conformingProtocols.append("Sendable")
+        }
+        
+        let conformingProtocolsString = conformingProtocols.joined(separator: ", ")
         fileBuilder.appendLine(" Enumeration restricting the values of the \(typeName) field.")
         fileBuilder.appendLine(" */")
-        fileBuilder.appendLine("public enum \(typeName): String, Codable, CustomStringConvertible, CaseIterable {", postInc: true)
+        fileBuilder.appendLine("public enum \(typeName): \(conformingProtocolsString) {", postInc: true)
         
         let sortedValues = valueConstraints.sorted { (left, right) in left.name < right.name }
         // iterate through the values

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelInvocationsReporting.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelInvocationsReporting.swift
@@ -48,12 +48,18 @@ public extension ServiceModelCodeGenerator {
             fileBuilder.appendLine("import \(libraryImport)")
         }
         
+        var reportingTypeConformance = ["HTTPClientCoreInvocationReporting"]
+        if case .enabled = self.customizations.addSendableConformance {
+            reportingTypeConformance.append("Sendable")
+        }
+        
+        let reportingTypeConformanceString = reportingTypeConformance.joined(separator: " & ")
         fileBuilder.appendLine("""
             
             /**
              Invocations reporting for the \(baseName)Model.
              */
-            public struct \(baseName)InvocationsReporting<InvocationReportingType: HTTPClientCoreInvocationReporting> {
+            public struct \(baseName)InvocationsReporting<InvocationReportingType: \(reportingTypeConformanceString)> {
             """)
         
         let sortedOperations = model.operationDescriptions.sorted { (left, right) in left.key < right.key }

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelStructures.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelStructures.swift
@@ -356,14 +356,21 @@ public extension ServiceModelCodeGenerator {
             formattedDocumentation.forEach { line in fileBuilder.appendLine(" \(line)") }
             fileBuilder.appendLine(" */")
         }
-
-        if !conformToShapeProtocol && !conformToValidatableProtocol {
-            fileBuilder.appendLine("public struct \(name): Codable, Equatable {", postInc: true)
-        } else if !conformToValidatableProtocol {
-            fileBuilder.appendLine("public struct \(name): Codable, Equatable, \(name)Shape {", postInc: true)
-        } else {
-            fileBuilder.appendLine("public struct \(name): Codable, Validatable, Equatable, \(name)Shape {", postInc: true)
+        
+        var conformingProtocols: [String] = ["Codable"]
+        if conformToValidatableProtocol {
+            conformingProtocols.append("Validatable")
         }
+        conformingProtocols.append("Equatable")
+        if case .enabled = self.customizations.addSendableConformance {
+            conformingProtocols.append("Sendable")
+        }
+        if conformToShapeProtocol {
+            conformingProtocols.append("\(name)Shape")
+        }
+        
+        let conformingProtocolsString = conformingProtocols.joined(separator: ", ")
+        fileBuilder.appendLine("public struct \(name): \(conformingProtocolsString) {", postInc: true)
         
         structureElements.variableDeclarationLines.forEach { lineDeclaration in
             if let documentation = lineDeclaration.documentation {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add support for additional code generation options. The default values of this options replicate the existing behaviour but changing these options will likely create a backwards-incompatible client.
1. addSendableConformance: Adds [Sendable](https://www.hackingwithswift.com/swift/5.5/sendable) conformance to generated structs and enums. Defaults to `disabled`.
2. eventLoopFutureClientAPIs: Generates or doesn't client APIs that return EventLoopFutures. Defaults to `enabled`. If `disabled`, removes EventLoopFutures completely from the public API of the client implementations.
3. minimumCompilerSupport: Tracks the minimum complier support required. Defaults to `unknown`. If not `unknown`, the generator will not provide condition compilation statements around code that uses async/await.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
