### PR TITLE
Provide the ability to create configuration object.

### DIFF
--- a/Sources/ServiceModelCodeGeneration/CodeGenerationCustomizations.swift
+++ b/Sources/ServiceModelCodeGeneration/CodeGenerationCustomizations.swift
@@ -24,6 +24,11 @@ public enum MinimumCompilerSupport: String, Codable {
     case v5_7 = "5.7"
 }
 
+public enum ClientConfigurationType: String, Codable {
+    case configurationObject = "CONFIGURATION_OBJECT"
+    case generator = "GENERATOR"
+}
+
 /**
  Specifies customizations to the code generation.
  */
@@ -46,6 +51,7 @@ public struct CodeGenerationCustomizations {
     public let addSendableConformance: CodeGenFeatureStatus
     public let eventLoopFutureClientAPIs: CodeGenFeatureStatus
     public let minimumCompilerSupport: MinimumCompilerSupport
+    public let clientConfigurationType: ClientConfigurationType
     
     public init(validationErrorDeclaration: ErrorDeclaration,
                 unrecognizedErrorDeclaration: ErrorDeclaration,
@@ -53,6 +59,7 @@ public struct CodeGenerationCustomizations {
                 eventLoopFutureClientAPIs: CodeGenFeatureStatus = .enabled,
                 addSendableConformance: CodeGenFeatureStatus = .disabled,
                 minimumCompilerSupport: MinimumCompilerSupport = .unknown,
+                clientConfigurationType: ClientConfigurationType = .generator,
                 generateModelShapeConversions: Bool,
                 optionalsInitializeEmpty: Bool,
                 fileHeader: String?,
@@ -63,6 +70,7 @@ public struct CodeGenerationCustomizations {
         self.eventLoopFutureClientAPIs = eventLoopFutureClientAPIs
         self.addSendableConformance = addSendableConformance
         self.minimumCompilerSupport = minimumCompilerSupport
+        self.clientConfigurationType = clientConfigurationType
         self.optionalsInitializeEmpty = optionalsInitializeEmpty
         self.fileHeader = fileHeader
         self.httpClientConfiguration = httpClientConfiguration

--- a/Sources/ServiceModelCodeGeneration/ModelClientDelegate.swift
+++ b/Sources/ServiceModelCodeGeneration/ModelClientDelegate.swift
@@ -23,6 +23,54 @@ public enum CodeGenFeatureStatus: String, Codable {
     case enabled = "ENABLED"
 }
 
+public enum ClientFileType {
+    case clientImplementation
+    case clientConfiguration
+    case clientGenerator
+    
+    public var isGenerator: Bool {
+        if case .clientGenerator = self {
+            return true
+        }
+        
+        return false
+    }
+}
+
+public struct InitializationStructs {
+    public let configurationObjectName: String
+    public let operationsClientName: String
+    
+    public init(configurationObjectName: String,
+                operationsClientName: String) {
+        self.configurationObjectName = configurationObjectName
+        self.operationsClientName = operationsClientName
+    }
+}
+
+public enum ClientEntityType {
+    case clientImplementation(initializationStructs: InitializationStructs?)
+    case configurationObject
+    case operationsClient(configurationObjectName: String)
+    case clientGenerator
+    
+    public var isGenerator: Bool {
+        if case .clientGenerator = self {
+            return true
+        }
+        
+        return false
+    }
+    
+    public var isClientImplementation: Bool {
+        if case .clientImplementation = self {
+            return true
+        }
+        
+        return false
+    }
+}
+
 /**
  Delegate protocol that can customize the generation of a client
  from the Service Model.
@@ -46,7 +94,7 @@ public protocol ModelClientDelegate {
     func addCustomFileHeader(codeGenerator: ServiceModelCodeGenerator,
                              delegate: ModelClientDelegate,
                              fileBuilder: FileBuilder,
-                             isGenerator: Bool)
+                             fileType: ClientFileType)
     
     /**
      Adds the type description to the header comment.
@@ -59,7 +107,7 @@ public protocol ModelClientDelegate {
     func addTypeDescription(codeGenerator: ServiceModelCodeGenerator,
                             delegate: ModelClientDelegate,
                             fileBuilder: FileBuilder,
-                            isGenerator: Bool)
+                            entityType: ClientEntityType)
     
     /**
      Add any common functions to the body of the client type.
@@ -74,7 +122,7 @@ public protocol ModelClientDelegate {
                             delegate: ModelClientDelegate,
                             fileBuilder: FileBuilder,
                             sortedOperations: [(String, OperationDescription)],
-                            isGenerator: Bool)
+                            entityType: ClientEntityType)
     
     /**
      Add the body for an operation to the client type.
@@ -97,7 +145,7 @@ public protocol ModelClientDelegate {
                           operationDescription: OperationDescription,
                           functionInputType: String?,
                           functionOutputType: String?,
-                          isGenerator: Bool)
+                          entityType: ClientEntityType)
 }
 
 /// The type of client being generated.

--- a/Sources/ServiceModelGenerate/ClientProtocolDelegate.swift
+++ b/Sources/ServiceModelGenerate/ClientProtocolDelegate.swift
@@ -52,14 +52,14 @@ public struct ClientProtocolDelegate: ModelClientDelegate {
     public func addTypeDescription(codeGenerator: ServiceModelCodeGenerator,
                                    delegate: ModelClientDelegate,
                                    fileBuilder: FileBuilder,
-                                   isGenerator: Bool) {
+                                   entityType: ClientEntityType) {
         fileBuilder.appendLine(self.typeDescription)
     }
     
     public func addCustomFileHeader(codeGenerator: ServiceModelCodeGenerator,
                                     delegate: ModelClientDelegate,
                                     fileBuilder: FileBuilder,
-                                    isGenerator: Bool) {
+                                    fileType: ClientFileType) {
         // no custom file header
     }
     
@@ -67,14 +67,14 @@ public struct ClientProtocolDelegate: ModelClientDelegate {
                                    delegate: ModelClientDelegate,
                                    fileBuilder: FileBuilder,
                                    sortedOperations: [(String, OperationDescription)],
-                                   isGenerator: Bool) {
+                                   entityType: ClientEntityType) {
         if case .enabled = self.eventLoopFutureClientAPIs {
             // for each of the operations
             for (name, operationDescription) in sortedOperations {
                 codeGenerator.addOperation(fileBuilder: fileBuilder, name: name,
                                            operationDescription: operationDescription,
                                            delegate: delegate, operationInvokeType: .eventLoopFutureAsync,
-                                           forTypeAlias: true, isGenerator: isGenerator)
+                                           forTypeAlias: true, entityType: entityType)
             }
         }
         
@@ -94,7 +94,7 @@ public struct ClientProtocolDelegate: ModelClientDelegate {
                 codeGenerator.addOperation(fileBuilder: fileBuilder, name: name,
                                            operationDescription: operationDescription,
                                            delegate: delegate, operationInvokeType: .asyncFunction,
-                                           forTypeAlias: true, isGenerator: isGenerator,
+                                           forTypeAlias: true, entityType: entityType,
                                            prefixLine: (index == 0 && requiresAsyncAwaitCondition) ? asyncAwaitCondition : nil,
                                            postfixLine: (index == sortedOperations.count - 1 && requiresAsyncAwaitCondition) ? "#else" : nil)
             }
@@ -107,7 +107,7 @@ public struct ClientProtocolDelegate: ModelClientDelegate {
                     codeGenerator.addOperation(fileBuilder: fileBuilder, name: name,
                                                operationDescription: operationDescription,
                                                delegate: delegate, operationInvokeType: .syncFunctionForNoAsyncAwaitSupport,
-                                               forTypeAlias: true, isGenerator: isGenerator,
+                                               forTypeAlias: true, entityType: entityType,
                                                postfixLine: (index == sortedOperations.count - 1) ? "#endif" : nil)
                 }
             }
@@ -119,7 +119,7 @@ public struct ClientProtocolDelegate: ModelClientDelegate {
                 codeGenerator.addOperation(fileBuilder: fileBuilder, name: name,
                                            operationDescription: operationDescription,
                                            delegate: delegate, operationInvokeType: .syncFunctionForNoAsyncAwaitSupport,
-                                           forTypeAlias: true, isGenerator: isGenerator)
+                                           forTypeAlias: true, entityType: entityType)
             }
         }
     }
@@ -131,7 +131,7 @@ public struct ClientProtocolDelegate: ModelClientDelegate {
                                  operationDescription: OperationDescription,
                                  functionInputType: String?,
                                  functionOutputType: String?,
-                                 isGenerator: Bool) {
+                                 entityType: ClientEntityType) {
         // nothing to do
     }
 }

--- a/Sources/ServiceModelGenerate/MockClientDelegate.swift
+++ b/Sources/ServiceModelGenerate/MockClientDelegate.swift
@@ -69,7 +69,7 @@ public struct MockClientDelegate: ModelClientDelegate {
     public func addTypeDescription(codeGenerator: ServiceModelCodeGenerator,
                                    delegate: ModelClientDelegate,
                                    fileBuilder: FileBuilder,
-                                   isGenerator: Bool) {
+                                   entityType: ClientEntityType) {
         let functionDetail: String
         let overrideDetail: String
         if case .enabled = eventLoopFutureClientAPIs {
@@ -108,7 +108,7 @@ public struct MockClientDelegate: ModelClientDelegate {
     public func addCustomFileHeader(codeGenerator: ServiceModelCodeGenerator,
                                     delegate: ModelClientDelegate,
                                     fileBuilder: FileBuilder,
-                                    isGenerator: Bool) {
+                                    fileType: ClientFileType) {
         fileBuilder.appendLine("""
             import SmokeAWSHttp
             """)
@@ -134,7 +134,7 @@ public struct MockClientDelegate: ModelClientDelegate {
                                    delegate: ModelClientDelegate,
                                    fileBuilder: FileBuilder,
                                    sortedOperations: [(String, OperationDescription)],
-                                   isGenerator: Bool) {
+                                   entityType: ClientEntityType) {
         if isThrowingMock {
             fileBuilder.appendLine("let error: \(baseName)Error")
         }
@@ -260,7 +260,7 @@ public struct MockClientDelegate: ModelClientDelegate {
                                  operationDescription: OperationDescription,
                                  functionInputType: String?,
                                  functionOutputType: String?,
-                                 isGenerator: Bool) {
+                                 entityType: ClientEntityType) {
         let hasInput = functionInputType != nil
         
         if isThrowingMock {

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateClient.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateClient.swift
@@ -46,8 +46,10 @@ public extension ServiceModelCodeGenerator {
         switch fileType {
         case .clientImplementation:
             fileNamePostfix = ""
-        case .clientGenerator, .clientConfiguration:
+        case .clientGenerator:
             fileNamePostfix = "Generator"
+        case .clientConfiguration:
+            fileNamePostfix = "Configuration"
         }
                 
         switch delegate.clientType {

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateClient.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateClient.swift
@@ -117,42 +117,24 @@ public extension ServiceModelCodeGenerator {
             return protocolTypeName + typePostfix
         case .struct(name: let structTypeName, _, _):
             if case .operationsClient = entityType {
-                return self.applicationDescription.baseName + typePostfix
-            } else {
-                return structTypeName + typePostfix
+                if structTypeName.hasSuffix("Client") {
+                    return structTypeName.dropLast("Client".count) + typePostfix
+                }
             }
+               
+            return structTypeName + typePostfix
         }
     }
     
     private func generateClient(delegate: ModelClientDelegate, entityType: ClientEntityType,
                                 fileBuilder: FileBuilder) {
-        let typeName: String
-        
-        let typePostfix: String
-        switch entityType {
-        case .clientImplementation:
-            typePostfix = ""
-        case .configurationObject:
-            typePostfix = "Configuration"
-        case .operationsClient:
-            typePostfix = "OperationsClient"
-        case .clientGenerator:
-            typePostfix = "Generator"
-        }
-        
+        let typeName = getTypeName(delegate: delegate, entityType: entityType)
         
         let typeDecaration: String
         switch delegate.clientType {
-        case .protocol(name: let protocolTypeName):
-            typeName = protocolTypeName + typePostfix
+        case .protocol:
             typeDecaration = "protocol \(typeName)"
-        case .struct(name: let structTypeName, genericParameters: let genericParameters, conformingProtocolNames: let protocolTypeNames):
-            if case .operationsClient = entityType {
-                typeName = self.applicationDescription.baseName + typePostfix
-            } else {
-                typeName = structTypeName + typePostfix
-            }
-            
+        case .struct(_, genericParameters: let genericParameters, conformingProtocolNames: let protocolTypeNames):
             if entityType.isGenerator {
                 typeDecaration = "struct \(typeName)"
             } else {

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateClient.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateClient.swift
@@ -85,7 +85,6 @@ public extension ServiceModelCodeGenerator {
             generateClient(delegate: delegate, entityType: .configurationObject, fileBuilder: fileBuilder)
             fileBuilder.appendEmptyLine()
             
-            
             let configurationObjectName = getTypeName(delegate: delegate, entityType: .configurationObject)
             
             generateClient(delegate: delegate, entityType: .operationsClient(configurationObjectName: configurationObjectName),

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateClient.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateClient.swift
@@ -36,13 +36,110 @@ public extension ServiceModelCodeGenerator {
      - Parameters:
         - delegate: The delegate to use when generating this client.
      */
-    func generateClient(delegate: ModelClientDelegate, isGenerator: Bool) {
+    func generateClient(delegate: ModelClientDelegate, fileType: ClientFileType) {
         let fileBuilder = FileBuilder()
         let baseName = applicationDescription.baseName
         
+        let fileName: String
+        
+        let fileNamePostfix: String
+        switch fileType {
+        case .clientImplementation:
+            fileNamePostfix = ""
+        case .clientGenerator, .clientConfiguration:
+            fileNamePostfix = "Generator"
+        }
+                
+        switch delegate.clientType {
+        case .protocol(name: let protocolTypeName):
+            fileName = protocolTypeName + fileNamePostfix
+        case .struct(name: let structTypeName, _, _):
+            fileName = structTypeName + fileNamePostfix
+        }
+        
+        addFileHeader(fileBuilder: fileBuilder, fileName: fileName,
+                      delegate: delegate, fileType: fileType)
+        
+        delegate.addCustomFileHeader(codeGenerator: self, delegate: delegate,
+                                     fileBuilder: fileBuilder, fileType: fileType)
+        
+        switch fileType {
+        case .clientImplementation:
+            let initializationStructs: InitializationStructs?
+            if case .configurationObject = self.customizations.clientConfigurationType {
+                let configurationObjectName = getTypeName(delegate: delegate, entityType: .configurationObject)
+                let operationsClientName = getTypeName(delegate: delegate,
+                                                       entityType: .operationsClient(configurationObjectName: configurationObjectName))
+                
+                initializationStructs = InitializationStructs(configurationObjectName: configurationObjectName,
+                                                              operationsClientName: operationsClientName)
+            } else {
+                initializationStructs = nil
+            }
+            
+            generateClient(delegate: delegate, entityType: .clientImplementation(initializationStructs: initializationStructs),
+                           fileBuilder: fileBuilder)
+        case .clientConfiguration:
+            generateClient(delegate: delegate, entityType: .configurationObject, fileBuilder: fileBuilder)
+            fileBuilder.appendEmptyLine()
+            
+            
+            let configurationObjectName = getTypeName(delegate: delegate, entityType: .configurationObject)
+            
+            generateClient(delegate: delegate, entityType: .operationsClient(configurationObjectName: configurationObjectName),
+                           fileBuilder: fileBuilder)
+        case .clientGenerator:
+            generateClient(delegate: delegate, entityType: .clientGenerator, fileBuilder: fileBuilder)
+        }
+        
+        let baseFilePath = applicationDescription.baseFilePath
+        
+        let fileNameWithExtension = "\(fileName).swift"
+        fileBuilder.write(toFile: fileNameWithExtension,
+                          atFilePath: "\(baseFilePath)/Sources/\(baseName)Client")
+    }
+    
+    private func getTypeName(delegate: ModelClientDelegate, entityType: ClientEntityType) -> String {
+        let typePostfix: String
+        switch entityType {
+        case .clientImplementation:
+            typePostfix = ""
+        case .configurationObject:
+            typePostfix = "Configuration"
+        case .operationsClient:
+            typePostfix = "OperationsClient"
+        case .clientGenerator:
+            typePostfix = "Generator"
+        }
+        
+        switch delegate.clientType {
+        case .protocol(name: let protocolTypeName):
+            return protocolTypeName + typePostfix
+        case .struct(name: let structTypeName, _, _):
+            if case .operationsClient = entityType {
+                return self.applicationDescription.baseName + typePostfix
+            } else {
+                return structTypeName + typePostfix
+            }
+        }
+    }
+    
+    private func generateClient(delegate: ModelClientDelegate, entityType: ClientEntityType,
+                                fileBuilder: FileBuilder) {
         let typeName: String
         
-        let typePostfix = isGenerator ? "Generator" : ""
+        let typePostfix: String
+        switch entityType {
+        case .clientImplementation:
+            typePostfix = ""
+        case .configurationObject:
+            typePostfix = "Configuration"
+        case .operationsClient:
+            typePostfix = "OperationsClient"
+        case .clientGenerator:
+            typePostfix = "Generator"
+        }
+        
         
         let typeDecaration: String
         switch delegate.clientType {
@@ -50,9 +147,13 @@ public extension ServiceModelCodeGenerator {
             typeName = protocolTypeName + typePostfix
             typeDecaration = "protocol \(typeName)"
         case .struct(name: let structTypeName, genericParameters: let genericParameters, conformingProtocolNames: let protocolTypeNames):
-            typeName = structTypeName + typePostfix
+            if case .operationsClient = entityType {
+                typeName = self.applicationDescription.baseName + typePostfix
+            } else {
+                typeName = structTypeName + typePostfix
+            }
             
-            if isGenerator {
+            if entityType.isGenerator {
                 typeDecaration = "struct \(typeName)"
             } else {
                 let genericParametersString: String
@@ -69,15 +170,14 @@ public extension ServiceModelCodeGenerator {
                 } else {
                     genericParametersString = ""
                 }
-                typeDecaration = "struct \(typeName)\(genericParametersString): \(protocolTypeNames.joined(separator: ", "))"
+                
+                if case .clientImplementation = entityType {
+                    typeDecaration = "struct \(typeName)\(genericParametersString): \(protocolTypeNames.joined(separator: ", "))"
+                } else {
+                    typeDecaration = "struct \(typeName)\(genericParametersString)"
+                }
             }
         }
-        
-        addFileHeader(fileBuilder: fileBuilder, typeName: typeName,
-                      delegate: delegate, isGenerator: isGenerator)
-        
-        delegate.addCustomFileHeader(codeGenerator: self, delegate: delegate,
-                                     fileBuilder: fileBuilder, isGenerator: isGenerator)
         
         fileBuilder.appendLine("""
             
@@ -86,7 +186,7 @@ public extension ServiceModelCodeGenerator {
         
         fileBuilder.inCommentBlock {
             delegate.addTypeDescription(codeGenerator: self, delegate: delegate,
-                                        fileBuilder: fileBuilder, isGenerator: isGenerator)
+                                        fileBuilder: fileBuilder, entityType: entityType)
         }
 
         fileBuilder.appendLine("""
@@ -100,7 +200,7 @@ public extension ServiceModelCodeGenerator {
         
         delegate.addCommonFunctions(codeGenerator: self, delegate: delegate,
                                     fileBuilder: fileBuilder,
-                                    sortedOperations: sortedOperations, isGenerator: isGenerator)
+                                    sortedOperations: sortedOperations, entityType: entityType)
         
         let requiresAsyncAwaitCondition: Bool
         if case .unknown = delegate.minimumCompilerSupport {
@@ -109,14 +209,14 @@ public extension ServiceModelCodeGenerator {
             requiresAsyncAwaitCondition = false
         }
         
-        if !isGenerator {
+        if case .clientImplementation = entityType {
             // for each of the operations
             if case .enabled = delegate.eventLoopFutureClientAPIs {
                 for (name, operationDescription) in sortedOperations {
                     addOperation(fileBuilder: fileBuilder, name: name,
                                  operationDescription: operationDescription,
                                  delegate: delegate, operationInvokeType: .eventLoopFutureAsync,
-                                 forTypeAlias: false, isGenerator: isGenerator)
+                                 forTypeAlias: false, entityType: entityType)
                 }
             }
             
@@ -128,18 +228,13 @@ public extension ServiceModelCodeGenerator {
                     addOperation(fileBuilder: fileBuilder, name: name,
                                  operationDescription: operationDescription,
                                  delegate: delegate, operationInvokeType: .asyncFunction,
-                                 forTypeAlias: false, isGenerator: isGenerator,
+                                 forTypeAlias: false, entityType: entityType,
                                  prefixLine: (index == 0 && requiresAsyncAwaitCondition) ? asyncAwaitCondition : nil,
                                  postfixLine: (index == sortedOperations.count - 1 && requiresAsyncAwaitCondition) ? "#endif" : nil)
                 }
             }
         }
         fileBuilder.appendLine("}", preDec: true)
-        let baseFilePath = applicationDescription.baseFilePath
-        
-        let fileName = "\(typeName).swift"
-        fileBuilder.write(toFile: fileName,
-                          atFilePath: "\(baseFilePath)/Sources/\(baseName)Client")
     }
     
     private func addOperationInput(fileBuilder: FileBuilder,
@@ -299,7 +394,7 @@ public extension ServiceModelCodeGenerator {
                                   delegate: ModelClientDelegate,
                                   invokeType: InvokeType, forTypeAlias: Bool,
                                   operationSignature: OperationSignature,
-                                  isGenerator: Bool) {
+                                  entityType: ClientEntityType) {
         let functionName: String
         if !forTypeAlias {
             fileBuilder.appendLine(" */")
@@ -339,7 +434,7 @@ public extension ServiceModelCodeGenerator {
                                   operationDescription: operationDescription,
                                   functionInputType: operationSignature.functionInputType,
                                   functionOutputType: operationSignature.functionOutputType,
-                                  isGenerator: isGenerator)
+                                  entityType: entityType)
     }
     
     enum OperationInvokeType {
@@ -364,7 +459,7 @@ public extension ServiceModelCodeGenerator {
                                operationDescription: OperationDescription,
                                delegate: ModelClientDelegate,
                                operationInvokeType: OperationInvokeType, forTypeAlias: Bool,
-                               isGenerator: Bool, prefixLine: String? = nil, postfixLine: String? = nil) {
+                               entityType: ClientEntityType, prefixLine: String? = nil, postfixLine: String? = nil) {
         // OperationInvokeType.syncFunctionForNoAsyncAwaitSupport is only an internal invoke state
         // for legacy support so we ignore it other than for where it is necessary
         let invokeType: InvokeType
@@ -422,7 +517,7 @@ public extension ServiceModelCodeGenerator {
         
         addOperationBody(fileBuilder: fileBuilder, name: name, operationDescription: operationDescription,
                          delegate: delegate, invokeType: invokeType, forTypeAlias: forTypeAlias,
-                         operationSignature: operationSignature, isGenerator: isGenerator)
+                         operationSignature: operationSignature, entityType: entityType)
         
         if let postfixLine = postfixLine {
             fileBuilder.appendLine(postfixLine)
@@ -440,9 +535,9 @@ public extension ServiceModelCodeGenerator {
     }
     
     private func addFileHeader(fileBuilder: FileBuilder,
-                               typeName: String,
+                               fileName: String,
                                delegate: ModelClientDelegate,
-                               isGenerator: Bool) {
+                               fileType: ClientFileType) {
         let baseName = applicationDescription.baseName
         if let fileHeader = customizations.fileHeader {
             fileBuilder.appendLine(fileHeader)
@@ -451,7 +546,7 @@ public extension ServiceModelCodeGenerator {
         addGeneratedFileHeader(fileBuilder: fileBuilder)
         
         fileBuilder.appendLine("""
-            // \(typeName).swift
+            // \(fileName).swift
             // \(baseName)Client
             //
             
@@ -468,7 +563,7 @@ public extension ServiceModelCodeGenerator {
             requiresNIOImport = false
         }
         
-        if requiresNIOImport && !isGenerator {
+        if requiresNIOImport && !fileType.isGenerator {
             fileBuilder.appendLine("""
                 import NIO
                 """)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This changes adds the initial support to generate a configuration type and operation client type for the generated client. This provides the ability to share client configuration and the underlying http client between generated clients respectively. These changes follow the already manually implemented additional configuration options in smoke-dynamodb.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
