### PR TITLE
Escape reverved words when generating the Error OptionSet

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -73,6 +73,7 @@ let package = Package(
         .target(
             name: "ServiceModelGenerate", dependencies: [
                 .target(name: "SwaggerServiceModel"),
+                .target(name: "ServiceModelEntities")
             ]
         ),
         .testTarget(

--- a/Sources/ServiceModelEntities/String+nameConversions.swift
+++ b/Sources/ServiceModelEntities/String+nameConversions.swift
@@ -85,15 +85,15 @@ public extension String {
         } else if normalizedName.hasSuffix("Exception") {
             return String(normalizedName.dropLast("Exception".count))
         }
-
+        
         return normalizedName
     }
     
-    static func escapeReservedWords(name: String) -> String {
-        if reservedWords.contains(name) {
-            return "`\(name)`"
+    func escapeReservedWords() -> String {
+        if reservedWords.contains(self) {
+            return "`\(self)`"
         }
         
-        return name
+        return self
     }
 }

--- a/Sources/ServiceModelEntities/String+nameConversions.swift
+++ b/Sources/ServiceModelEntities/String+nameConversions.swift
@@ -17,6 +17,9 @@
 
 import Foundation
 
+private let reservedWords: Set<String> = ["in", "protocol", "return", "default", "public", "self",
+                                          "static", "private", "internal", "do", "is", "as", "true", "false", "import"]
+
 public extension String {
     /**
      This string starting with an uppercase.
@@ -84,5 +87,13 @@ public extension String {
         }
 
         return normalizedName
+    }
+    
+    static func escapeReservedWords(name: String) -> String {
+        if reservedWords.contains(name) {
+            return "`\(name)`"
+        }
+        
+        return name
     }
 }

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelErrors.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelErrors.swift
@@ -221,7 +221,7 @@ public extension ServiceModelCodeGenerator {
         // for each of the errors
         for (index, error) in sortedErrors.enumerated() {
             let internalName = error.normalizedName
-            fileBuilder.appendLine("    public static let \(String.escapeReservedWords(name: internalName)) = \(baseName)ErrorTypes(rawValue: \(index + 1))")
+            fileBuilder.appendLine("    public static let \(internalName.escapeReservedWords()) = \(baseName)ErrorTypes(rawValue: \(index + 1))")
         }
         
         delegate.errorTypeAdditionalOptionSetItems(fileBuilder: fileBuilder,

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelErrors.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelErrors.swift
@@ -221,7 +221,7 @@ public extension ServiceModelCodeGenerator {
         // for each of the errors
         for (index, error) in sortedErrors.enumerated() {
             let internalName = error.normalizedName
-            fileBuilder.appendLine("    public static let \(internalName) = \(baseName)ErrorTypes(rawValue: \(index + 1))")
+            fileBuilder.appendLine("    public static let \(String.escapeReservedWords(name: internalName)) = \(baseName)ErrorTypes(rawValue: \(index + 1))")
         }
         
         delegate.errorTypeAdditionalOptionSetItems(fileBuilder: fileBuilder,

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+shapeUtilityFunctions.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+shapeUtilityFunctions.swift
@@ -218,7 +218,7 @@ public extension ServiceModelCodeGenerator {
         }
         let internalName = modelTypeName.prefix(1).lowercased() + modelTypeName.dropFirst()
         
-        let variableName = reservedWordsAllowed ? internalName : String.escapeReservedWords(name: internalName)
+        let variableName = reservedWordsAllowed ? internalName : internalName.escapeReservedWords()
         
         return variableName.safeModelName(replacement: "",
                                  wildCardReplacement: "Star")
@@ -239,20 +239,20 @@ public extension ServiceModelCodeGenerator {
                                                                     wildCardReplacement: "Star")
             
             // convert from upper camel case
-            return String.escapeReservedWords(name: modifiedModelTypeName.upperToLowerCamelCase)
+            return modifiedModelTypeName.upperToLowerCamelCase.escapeReservedWords()
         } else if let usingUpperCamelCase = modelOverride?.enumerations?.usingUpperCamelCase,
             usingUpperCamelCase.contains("\(inStructure).\(modelTypeName)") {
             let modifiedModelTypeName = modelTypeName.safeModelName(replacement: "",
                                                                     wildCardReplacement: "Star")
             
             // convert from upper camel case
-            return String.escapeReservedWords(name: modifiedModelTypeName.upperToLowerCamelCase)
+            return modifiedModelTypeName.upperToLowerCamelCase.escapeReservedWords()
         } else if usingUpperCamelCase {
             let modifiedModelTypeName = modelTypeName.safeModelName(replacement: "",
                                                                     wildCardReplacement: "Star")
             
             // convert from upper camel case
-            return String.escapeReservedWords(name: modifiedModelTypeName.upperToLowerCamelCase)
+            return modifiedModelTypeName.upperToLowerCamelCase.escapeReservedWords()
         }
         
         let modifiedModelTypeName = modelTypeName.safeModelName(replacement: "_",
@@ -276,6 +276,6 @@ public extension ServiceModelCodeGenerator {
             firstCharacter.unicodeScalars[firstCharacter.startIndex]) {
             return "_\(convertedName)"
         }
-        return String.escapeReservedWords(name: convertedName)
+        return convertedName.escapeReservedWords()
     }
 }

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+shapeUtilityFunctions.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+shapeUtilityFunctions.swift
@@ -17,9 +17,7 @@
 
 import Foundation
 import ServiceModelCodeGeneration
-
-private let reservedWords: Set<String> = ["in", "protocol", "return", "default", "public", "self",
-                                          "static", "private", "internal", "do", "is", "as", "true", "false", "import"]
+import ServiceModelEntities
 
 public enum ShapeCategory {
     case protocolType(String)
@@ -204,14 +202,6 @@ public extension ServiceModelCodeGenerator {
         return shapeCategory
     }
     
-    private func escapeReservedWords(name: String) -> String {
-        if reservedWords.contains(name) {
-            return "`\(name)`"
-        }
-        
-        return name
-    }
-    
     /**
      Returns the normalized name of variable for a type.
      
@@ -228,7 +218,7 @@ public extension ServiceModelCodeGenerator {
         }
         let internalName = modelTypeName.prefix(1).lowercased() + modelTypeName.dropFirst()
         
-        let variableName = reservedWordsAllowed ? internalName : escapeReservedWords(name: internalName)
+        let variableName = reservedWordsAllowed ? internalName : String.escapeReservedWords(name: internalName)
         
         return variableName.safeModelName(replacement: "",
                                  wildCardReplacement: "Star")
@@ -249,20 +239,20 @@ public extension ServiceModelCodeGenerator {
                                                                     wildCardReplacement: "Star")
             
             // convert from upper camel case
-            return escapeReservedWords(name: modifiedModelTypeName.upperToLowerCamelCase)
+            return String.escapeReservedWords(name: modifiedModelTypeName.upperToLowerCamelCase)
         } else if let usingUpperCamelCase = modelOverride?.enumerations?.usingUpperCamelCase,
             usingUpperCamelCase.contains("\(inStructure).\(modelTypeName)") {
             let modifiedModelTypeName = modelTypeName.safeModelName(replacement: "",
                                                                     wildCardReplacement: "Star")
             
             // convert from upper camel case
-            return escapeReservedWords(name: modifiedModelTypeName.upperToLowerCamelCase)
+            return String.escapeReservedWords(name: modifiedModelTypeName.upperToLowerCamelCase)
         } else if usingUpperCamelCase {
             let modifiedModelTypeName = modelTypeName.safeModelName(replacement: "",
                                                                     wildCardReplacement: "Star")
             
             // convert from upper camel case
-            return escapeReservedWords(name: modifiedModelTypeName.upperToLowerCamelCase)
+            return String.escapeReservedWords(name: modifiedModelTypeName.upperToLowerCamelCase)
         }
         
         let modifiedModelTypeName = modelTypeName.safeModelName(replacement: "_",
@@ -286,6 +276,6 @@ public extension ServiceModelCodeGenerator {
             firstCharacter.unicodeScalars[firstCharacter.startIndex]) {
             return "_\(convertedName)"
         }
-        return escapeReservedWords(name: convertedName)
+        return String.escapeReservedWords(name: convertedName)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes a bug where the member names under the Error OptionSet can be reserved words. For example, an error called `InternalException` would produce a variable with the name `internal`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
