### PR TITLE
Fix codegen when minimumCompilerSupport != unknown and eventLoopFutureClientAPIs == ENABLED

### DIFF
--- a/Sources/ServiceModelGenerate/MockClientDelegate.swift
+++ b/Sources/ServiceModelGenerate/MockClientDelegate.swift
@@ -516,17 +516,15 @@ public struct MockClientDelegate: ModelClientDelegate {
                                                    operationName: operationName)
             if case .unknown = minimumCompilerSupport {
                 fileBuilder.appendLine("#else", preDec: true, postInc: true)
-            }
             
-            delegateMockThrowingImplementationCall(codeGenerator: codeGenerator,
-                                                   functionPrefix: functionPrefix,
-                                                   functionInfix: functionInfix,
-                                                   fileBuilder: fileBuilder,
-                                                   hasInput: hasInput,
-                                                   functionOutputType: functionOutputType,
-                                                   operationName: operationName)
+                delegateMockThrowingImplementationCall(codeGenerator: codeGenerator,
+                                                       functionPrefix: functionPrefix,
+                                                       functionInfix: functionInfix,
+                                                       fileBuilder: fileBuilder,
+                                                       hasInput: hasInput,
+                                                       functionOutputType: functionOutputType,
+                                                       operationName: operationName)
             
-            if case .unknown = minimumCompilerSupport {
                 fileBuilder.appendLine("#endif", preDec: true)
             }
         } else {


### PR DESCRIPTION
*Issue #, if available:* Previously both the async aware and pre-async bodies were generated with this combination of options-

```
        return mockAsyncAwareEventLoopFutureExecuteWithInputWithOutput(
            input: input,
            defaultResult: TheResponse.__default,
            eventLoop: self.eventLoop,
            functionOverride: self.theAPIFunctionOverride,
            eventLoopFutureFunctionOverride: self.theAPIEventLoopFutureAsyncOverride)
        return mockEventLoopFutureExecuteWithInputWithOutput(
            input: input,
            defaultResult: TheResponse.__default,
            eventLoop: self.eventLoop,
            functionOverride: self.theAPIFunctionOverride,
            eventLoopFutureFunctionOverride: self.theAPIEventLoopFutureAsyncOverride)
```

This change stops the pre-async body from being emitted.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
