### PR TITLE
Support custom target names.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,26 +12,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        swift: ["5.6", "5.5.3"]
+        swift: ["5.7", "5.6.3", "5.5.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: fwal/setup-swift@v1.14.0
+      - uses: swift-actions/setup-swift@v1.18.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
       - name: Build
         run: swift build -c release
-  BuildOpenAPIWorkaround:
-    name: Swift ${{ matrix.swift }} on ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04]
-        swift: ["5.4.3"]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: fwal/setup-swift@v1.14.0
-        with:
-          swift-version: ${{ matrix.swift }}
-      - uses: actions/checkout@v2
-      - name: Build
-        run: swift build -Xswiftc -Xfrontend -Xswiftc -sil-verify-none -c release

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/amzn/service-model-swift-code-generate/actions/workflows/swift.yml/badge.svg?branch=main" alt="Build - main Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.4|5.5|5.6-orange.svg?style=flat" alt="Swift 5.4, 5.5 and 5.6 Tested">
+<img src="https://img.shields.io/badge/swift-5.5|5.6|5.7-orange.svg?style=flat" alt="Swift 5.5, 5.6 and 5.7 Tested">
 </a>
 <a href="https://gitter.im/SmokeServerSide">
 <img src="https://img.shields.io/badge/chat-on%20gitter-ee115e.svg?style=flat" alt="Join the Smoke Server Side community on gitter">

--- a/Sources/ServiceModelGenerate/ClientProtocolDelegate.swift
+++ b/Sources/ServiceModelGenerate/ClientProtocolDelegate.swift
@@ -26,6 +26,7 @@ import ServiceModelEntities
 public struct ClientProtocolDelegate: ModelClientDelegate {
     public let clientType: ClientType
     public let baseName: String
+    public let modelTargetName: String
     public let typeDescription: String
     public let asyncAwaitAPIs: CodeGenFeatureStatus
     public let eventLoopFutureClientAPIs: CodeGenFeatureStatus
@@ -38,10 +39,11 @@ public struct ClientProtocolDelegate: ModelClientDelegate {
         - baseName: The base name of the Service.
         - asyncResultType: The name of the result type to use for async functions.
      */
-    public init(baseName: String, asyncAwaitAPIs: CodeGenFeatureStatus,
+    public init(baseName: String, modelTargetName: String, asyncAwaitAPIs: CodeGenFeatureStatus,
                 eventLoopFutureClientAPIs: CodeGenFeatureStatus = .enabled,
                 minimumCompilerSupport: MinimumCompilerSupport = .unknown) {
         self.baseName = baseName
+        self.modelTargetName = modelTargetName
         self.clientType = .protocol(name: "\(baseName)ClientProtocol")
         self.typeDescription = "Client Protocol for the \(baseName) service."
         self.asyncAwaitAPIs = asyncAwaitAPIs
@@ -71,7 +73,7 @@ public struct ClientProtocolDelegate: ModelClientDelegate {
         if case .enabled = self.eventLoopFutureClientAPIs {
             // for each of the operations
             for (name, operationDescription) in sortedOperations {
-                codeGenerator.addOperation(fileBuilder: fileBuilder, name: name,
+                codeGenerator.addOperation(modelTargetName: self.modelTargetName, fileBuilder: fileBuilder, name: name,
                                            operationDescription: operationDescription,
                                            delegate: delegate, operationInvokeType: .eventLoopFutureAsync,
                                            forTypeAlias: true, entityType: entityType)
@@ -91,7 +93,7 @@ public struct ClientProtocolDelegate: ModelClientDelegate {
             for (index, operation) in sortedOperations.enumerated() {
                 let (name, operationDescription) = operation
                 
-                codeGenerator.addOperation(fileBuilder: fileBuilder, name: name,
+                codeGenerator.addOperation(modelTargetName: modelTargetName, fileBuilder: fileBuilder, name: name,
                                            operationDescription: operationDescription,
                                            delegate: delegate, operationInvokeType: .asyncFunction,
                                            forTypeAlias: true, entityType: entityType,
@@ -104,7 +106,7 @@ public struct ClientProtocolDelegate: ModelClientDelegate {
                 for (index, operation) in sortedOperations.enumerated() {
                     let (name, operationDescription) = operation
                     
-                    codeGenerator.addOperation(fileBuilder: fileBuilder, name: name,
+                    codeGenerator.addOperation(modelTargetName: modelTargetName, fileBuilder: fileBuilder, name: name,
                                                operationDescription: operationDescription,
                                                delegate: delegate, operationInvokeType: .syncFunctionForNoAsyncAwaitSupport,
                                                forTypeAlias: true, entityType: entityType,
@@ -116,7 +118,7 @@ public struct ClientProtocolDelegate: ModelClientDelegate {
             for operation in sortedOperations {
                 let (name, operationDescription) = operation
                 
-                codeGenerator.addOperation(fileBuilder: fileBuilder, name: name,
+                codeGenerator.addOperation(modelTargetName: modelTargetName, fileBuilder: fileBuilder, name: name,
                                            operationDescription: operationDescription,
                                            delegate: delegate, operationInvokeType: .syncFunctionForNoAsyncAwaitSupport,
                                            forTypeAlias: true, entityType: entityType)

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+createOutputStructureStubVariable.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+createOutputStructureStubVariable.swift
@@ -25,9 +25,9 @@ internal extension ServiceModelCodeGenerator {
             fileBuilder: FileBuilder,
             declarationPrefix: String,
             memberLocation: [String: LocationOutput],
-            payloadAsMember: String?) {
+            payloadAsMember: String?,
+            modelTargetName: String) {
         var outputLines: [String] = []
-        let baseName = applicationDescription.baseName
         
         // if there isn't actually a structure of the type, this is a fatal
         guard let structureDefinition = model.structureDescriptions[type] else {
@@ -40,9 +40,9 @@ internal extension ServiceModelCodeGenerator {
         }
         
         if sortedMembers.isEmpty {
-            outputLines.append("\(declarationPrefix) \(baseName)Model.\(type)()")
+            outputLines.append("\(declarationPrefix) \(modelTargetName).\(type)()")
         } else {
-            outputLines.append("\(declarationPrefix) \(baseName)Model.\(type)(")
+            outputLines.append("\(declarationPrefix) \(modelTargetName).\(type)(")
         }
         
         // iterate through each property
@@ -84,7 +84,7 @@ internal extension ServiceModelCodeGenerator {
         
         // output the declaration
         if outputLines.isEmpty {
-            fileBuilder.appendLine("\(declarationPrefix) \(baseName)Model.\(type)()")
+            fileBuilder.appendLine("\(declarationPrefix) \(modelTargetName).\(type)()")
         } else {
             outputLines.forEach { line in fileBuilder.appendLine(line) }
         }

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+createStructureStubVariable.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+createStructureStubVariable.swift
@@ -34,12 +34,12 @@ internal extension ServiceModelCodeGenerator {
             aborted as early as possible.
      */
     func createStructureStubVariable(type: String,
+                                     modelTargetName: String,
                                      fileBuilder: FileBuilder,
                                      declarationPrefix: String,
                                      fatalOnError: Bool,
                                      overrideFieldNameProvider: ((String) -> String?)? = nil) {
         var outputLines: [String] = []
-        let baseName = applicationDescription.baseName
         
         // if there isn't actually a structure of the type, this is a fatal
         guard let structureDefinition = model.structureDescriptions[type] else {
@@ -70,9 +70,9 @@ internal extension ServiceModelCodeGenerator {
         }
         
         if sortedMembers.isEmpty {
-            outputLines.append("\(declarationPrefix) \(baseName)Model.\(type)()")
+            outputLines.append("\(declarationPrefix) \(modelTargetName).\(type)()")
         } else {
-            outputLines.append("\(declarationPrefix) \(baseName)Model.\(type)(")
+            outputLines.append("\(declarationPrefix) \(modelTargetName).\(type)(")
         }
         
         // iterate through each property
@@ -85,7 +85,7 @@ internal extension ServiceModelCodeGenerator {
         
         // output the declaration
         if outputLines.isEmpty {
-            fileBuilder.appendLine("\(declarationPrefix) \(baseName)Model.\(type)()")
+            fileBuilder.appendLine("\(declarationPrefix) \(modelTargetName).\(type)()")
         } else {
             outputLines.forEach { line in fileBuilder.appendLine(line) }
         }

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateConversionFunctions.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateConversionFunctions.swift
@@ -20,11 +20,10 @@ import ServiceModelCodeGeneration
 import ServiceModelEntities
 
 extension ServiceModelCodeGenerator {
-    func createArrayConversionFunction(fileBuilder: FileBuilder,
+    func createArrayConversionFunction(modelTargetName: String, fileBuilder: FileBuilder,
                                        name: String, innerType: String) {
         let typeName = name.getNormalizedTypeName(forModel: model)
         let innerTypeName = innerType.getNormalizedTypeName(forModel: model)
-        let baseName = applicationDescription.baseName
         
         let willConversionFail = willShapeConversionFail(fieldName: innerType, alreadySeenShapes: [])
         
@@ -48,8 +47,8 @@ extension ServiceModelCodeGenerator {
             fileBuilder.appendLine("""
             
             public extension Array where Element: \(type) {
-               func as\(baseName)Model\(typeName)()\(failPostfix) -> \(baseName)Model.\(typeName) {
-                   return \(tryPrefix)self.map { \(tryPrefix)$0.as\(baseName)Model\(innerTypeName)() }
+               func as\(modelTargetName)\(typeName)()\(failPostfix) -> \(modelTargetName).\(typeName) {
+                   return \(tryPrefix)self.map { \(tryPrefix)$0.as\(modelTargetName)\(innerTypeName)() }
                }
             }
             """)
@@ -62,8 +61,8 @@ extension ServiceModelCodeGenerator {
             fileBuilder.appendLine("""
             
             public extension Array where \(whereClause) {
-               func as\(baseName)Model\(typeName)()\(failPostfix) -> \(baseName)Model.\(typeName) {
-                   return \(tryPrefix)self.map { \(tryPrefix)$0.as\(baseName)Model\(innerTypeName)() }
+               func as\(modelTargetName)\(typeName)()\(failPostfix) -> \(modelTargetName).\(typeName) {
+                   return \(tryPrefix)self.map { \(tryPrefix)$0.as\(modelTargetName)\(innerTypeName)() }
                }
             }
             """)
@@ -71,18 +70,17 @@ extension ServiceModelCodeGenerator {
             fileBuilder.appendLine("""
             
             public extension Array where Element: CustomStringConvertible {
-               func as\(baseName)Model\(typeName)()\(failPostfix) -> \(baseName)Model.\(typeName) {
-                   return \(tryPrefix)self.map { \(tryPrefix)$0.as\(baseName)Model\(innerTypeName)() }
+               func as\(modelTargetName)\(typeName)()\(failPostfix) -> \(modelTargetName).\(typeName) {
+                   return \(tryPrefix)self.map { \(tryPrefix)$0.as\(modelTargetName)\(innerTypeName)() }
                }
             }
             """)
         }
     }
 
-    func createMapConversionFunction(fileBuilder: FileBuilder,
+    func createMapConversionFunction(modelTargetName: String, fileBuilder: FileBuilder,
                                      name: String, valueType: String) {
         let typeName = name.getNormalizedTypeName(forModel: model)
-        let baseName = applicationDescription.baseName
         
         let willConversionFail = willShapeConversionFail(fieldName: valueType, alreadySeenShapes: [])
         
@@ -106,8 +104,8 @@ extension ServiceModelCodeGenerator {
             fileBuilder.appendLine("""
             
             public extension Dictionary where Key == String, Value: \(type) {
-               func as\(baseName)Model\(typeName)()\(failPostfix) -> \(baseName)Model.\(typeName) {
-                   return \(tryPrefix)self.mapValues { \(tryPrefix)$0.as\(baseName)Model\(valueType)() }
+               func as\(modelTargetName)\(typeName)()\(failPostfix) -> \(modelTargetName).\(typeName) {
+                   return \(tryPrefix)self.mapValues { \(tryPrefix)$0.as\(modelTargetName)\(valueType)() }
                }
             }
             """)
@@ -120,8 +118,8 @@ extension ServiceModelCodeGenerator {
             fileBuilder.appendLine("""
             
             public extension Dictionary where Key == String, \(whereClause) {
-               func as\(baseName)Model\(typeName)()\(failPostfix) -> \(baseName)Model.\(typeName) {
-                   return \(tryPrefix)self.mapValues { \(tryPrefix)$0.as\(baseName)Model\(valueType)() }
+               func as\(modelTargetName)\(typeName)()\(failPostfix) -> \(modelTargetName).\(typeName) {
+                   return \(tryPrefix)self.mapValues { \(tryPrefix)$0.as\(modelTargetName)\(valueType)() }
                }
             }
             """)
@@ -129,8 +127,8 @@ extension ServiceModelCodeGenerator {
             fileBuilder.appendLine("""
             
             public extension Dictionary where Value: CustomStringConvertible {
-               func as\(baseName)Model\(typeName)()\(failPostfix) -> \(baseName)Model.\(typeName) {
-                   return \(tryPrefix)self.mapValues { \(tryPrefix)$0.as\(baseName)Model\(valueType)() }
+               func as\(modelTargetName)\(typeName)()\(failPostfix) -> \(modelTargetName).\(typeName) {
+                   return \(tryPrefix)self.mapValues { \(tryPrefix)$0.as\(modelTargetName)\(valueType)() }
                }
             }
             """)

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateDefaultInstances.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateDefaultInstances.swift
@@ -31,7 +31,8 @@ public extension ServiceModelCodeGenerator {
      - Parameters:
         - generationType: The type of test input to generate.
      */
-    func generateDefaultInstances(generationType: DefaultInstancesGenerationType) {
+    func generateDefaultInstances(generationType: DefaultInstancesGenerationType,
+                                  modelTargetName: String) {
         
         let fileBuilder = FileBuilder()
         let baseName = applicationDescription.baseName
@@ -43,7 +44,7 @@ public extension ServiceModelCodeGenerator {
         
         fileBuilder.appendLine("""
             // \(baseName)ModelDefaultInstances.swift
-            // \(baseName)Model
+            // \(modelTargetName)
             //
             
             import Foundation
@@ -67,13 +68,13 @@ public extension ServiceModelCodeGenerator {
         
         // iterate through the structures
         for (name, _) in sortedStructures {
-            addDefaultStructureInstance(generationType: generationType, fileBuilder: fileBuilder, name: name,
-                                        baseName: baseName, getOverrideFieldName: getOverrideFieldName)
+            addDefaultStructureInstance(generationType: generationType, modelTargetName: modelTargetName, fileBuilder: fileBuilder,
+                                        name: name, getOverrideFieldName: getOverrideFieldName)
         }
         
         let fileName = "\(baseName)ModelDefaultInstances.swift"
         let baseFilePath = applicationDescription.baseFilePath
-        fileBuilder.write(toFile: fileName, atFilePath: "\(baseFilePath)/Sources/\(baseName)Model")
+        fileBuilder.write(toFile: fileName, atFilePath: "\(baseFilePath)/Sources/\(modelTargetName)")
     }
     
     private func addDefaultValues(_ fileBuilder: FileBuilder) {
@@ -98,8 +99,8 @@ public extension ServiceModelCodeGenerator {
         }
     }
     
-    private func addDefaultStructureInstance(generationType: DefaultInstancesGenerationType, fileBuilder: FileBuilder,
-                                             name: String, baseName: String, getOverrideFieldName: @escaping (String) -> String?) {
+    private func addDefaultStructureInstance(generationType: DefaultInstancesGenerationType, modelTargetName: String,
+                                             fileBuilder: FileBuilder, name: String, getOverrideFieldName: @escaping (String) -> String?) {
         switch generationType {
         case .internalTypes:
             // create a function that returns the default instance of this structure
@@ -109,11 +110,11 @@ public extension ServiceModelCodeGenerator {
                     /**
                      Default instance of the \(name) structure.
                      */
-                    static let __default: \(baseName)Model.\(name) = {
+                    static let __default: \(modelTargetName).\(name) = {
                 """)
             fileBuilder.incIndent()
             fileBuilder.incIndent()
-            createStructureStubVariable(type: name,
+            createStructureStubVariable(type: name, modelTargetName: modelTargetName,
                                         fileBuilder: fileBuilder,
                                         declarationPrefix: "let defaultInstance =",
                                         fatalOnError: true,

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateEnumerationDeclaration.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateEnumerationDeclaration.swift
@@ -31,9 +31,9 @@ extension ServiceModelCodeGenerator {
      */
     func generateEnumerationDeclaration(fileBuilder: FileBuilder,
                                         name: String,
+                                        modelTargetName: String,
                                         valueConstraints: [(name: String, value: String)]) {
         let typeName = name.getNormalizedTypeName(forModel: model)
-        let baseName = applicationDescription.baseName
         
         fileBuilder.appendEmptyLine()
         fileBuilder.appendLine("/**")
@@ -85,12 +85,12 @@ extension ServiceModelCodeGenerator {
             fileBuilder.appendEmptyLine()
             fileBuilder.appendLine("""
                 public extension CustomStringConvertible {
-                    func as\(baseName)Model\(typeName)() throws -> \(baseName)Model.\(typeName) {
+                    func as\(modelTargetName)\(typeName)() throws -> \(modelTargetName).\(typeName) {
                         let description = self.description
                 
                         guard let result = \(typeName)(rawValue: description) else {
                             throw \(validationErrorType).validationError(reason: "Unable to convert value '"
-                                + description + "' to a \(baseName)Model.\(name) value.")
+                                + description + "' to a \(modelTargetName).\(name) value.")
                         }
                 
                         return result

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelErrors.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelErrors.swift
@@ -26,7 +26,8 @@ public extension ServiceModelCodeGenerator {
      - Parameters:
         - delegate: The delegate to use when generating this client.
      */
-    func generateModelErrors(delegate: ModelErrorsDelegate) {
+    func generateModelErrors(delegate: ModelErrorsDelegate,
+                             modelTargetName: String) {
         
         let fileBuilder = FileBuilder()
         let baseName = applicationDescription.baseName
@@ -38,7 +39,7 @@ public extension ServiceModelCodeGenerator {
         
         fileBuilder.appendLine("""
             // \(baseName)ModelErrors.swift
-            // \(baseName)Model
+            // \(modelTargetName)
             //
             
             import Foundation
@@ -89,7 +90,7 @@ public extension ServiceModelCodeGenerator {
         }
         
         let fileName = "\(baseName)ModelErrors.swift"
-        fileBuilder.write(toFile: fileName, atFilePath: "\(applicationDescription.baseFilePath)/Sources/\(baseName)Model")
+        fileBuilder.write(toFile: fileName, atFilePath: "\(applicationDescription.baseFilePath)/Sources/\(modelTargetName)")
     }
     
     func getSortedErrors(allErrorTypes: Set<String>) -> [ErrorType] {

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelInvocationsReporting.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelInvocationsReporting.swift
@@ -23,7 +23,8 @@ public extension ServiceModelCodeGenerator {
     /**
      Generate an operation enumeration for the model.
      */
-    func generateInvocationsReporting() {
+    func generateInvocationsReporting(modelTargetName: String,
+                                      clientTargetName: String) {
         
         let fileBuilder = FileBuilder()
         let baseName = applicationDescription.baseName
@@ -35,13 +36,13 @@ public extension ServiceModelCodeGenerator {
         
         fileBuilder.appendLine("""
             // \(baseName)InvocationsReporting.swift
-            // \(baseName)Client
+            // \(clientTargetName)
             //
             
             import Foundation
             import SmokeHTTPClient
             import SmokeAWSHttp
-            import \(baseName)Model
+            import \(modelTargetName)
             """)
         
         if case let .external(libraryImport: libraryImport, _) = customizations.validationErrorDeclaration {
@@ -57,7 +58,7 @@ public extension ServiceModelCodeGenerator {
         fileBuilder.appendLine("""
             
             /**
-             Invocations reporting for the \(baseName)Model.
+             Invocations reporting for the \(modelTargetName).
              */
             public struct \(baseName)InvocationsReporting<InvocationReportingType: \(reportingTypeConformanceString)> {
             """)
@@ -75,7 +76,7 @@ public extension ServiceModelCodeGenerator {
         
         let fileName = "\(baseName)InvocationsReporting.swift"
         let baseFilePath = applicationDescription.baseFilePath
-        fileBuilder.write(toFile: fileName, atFilePath: "\(baseFilePath)/Sources/\(baseName)Client")
+        fileBuilder.write(toFile: fileName, atFilePath: "\(baseFilePath)/Sources/\(clientTargetName)")
     }
     
     private func addOperationReportingParameters(fileBuilder: FileBuilder, baseName: String,

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelOperationClientInput.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelOperationClientInput.swift
@@ -35,7 +35,7 @@ public extension ServiceModelCodeGenerator {
     /**
      Generate client input for each operation.
      */
-    func generateModelOperationClientInput() {
+    func generateModelOperationClientInput(modelTargetName: String, clientTargetName: String) {
         let baseName = applicationDescription.baseName
         
         let fileBuilder = FileBuilder()
@@ -48,12 +48,12 @@ public extension ServiceModelCodeGenerator {
         
         fileBuilder.appendLine("""
             // \(baseName)OperationsClientInput.swift
-            // \(baseName)Client
+            // \(clientTargetName)
             //
             
             import Foundation
             import SmokeHTTPClient
-            import \(baseName)Model
+            import \(modelTargetName)
             """)
         
         if case let .external(libraryImport: libraryImport, _) = customizations.validationErrorDeclaration {
@@ -65,13 +65,13 @@ public extension ServiceModelCodeGenerator {
         sortedOperations.forEach { operation in
             addOperationHTTPRequestInput(operation: operation.key,
                                          operationDescription: operation.value,
-                                         generationType: .requestInput,
+                                         generationType: .requestInput, modelTargetName: modelTargetName,
                                          fileBuilder: fileBuilder)
         }
         
         let fileName = "\(baseName)OperationsClientInput.swift"
         let baseFilePath = applicationDescription.baseFilePath
-        fileBuilder.write(toFile: fileName, atFilePath: "\(baseFilePath)/Sources/\(baseName)Client")
+        fileBuilder.write(toFile: fileName, atFilePath: "\(baseFilePath)/Sources/\(clientTargetName)")
     }
     
     private func addPathOperationHTTPRequestInput(pathMembers: [String: Member],
@@ -79,10 +79,10 @@ public extension ServiceModelCodeGenerator {
                                                   operationPrefix: String,
                                                   name: String,
                                                   generationType: ServiceModelCodeGenerator.ClientInputGenerationType,
+                                                  modelTargetName: String,
                                                   fileBuilder: FileBuilder) -> (pathTypeName: String, pathTypeConversion: String) {
         let pathTypeName: String
         let pathTypeConversion: String
-        let baseName = applicationDescription.baseName
         if !pathMembers.isEmpty {
             pathTypeName = "\(operationPrefix)Path"
             let structureDefinition = StructureDescription(
@@ -92,6 +92,7 @@ public extension ServiceModelCodeGenerator {
             if case .supportingStructures = generationType {
                 generateStructure(name: pathTypeName,
                                   structureDescription: structureDefinition,
+                                  modelTargetName: modelTargetName,
                                   fileBuilder: fileBuilder,
                                   includeVariableDocumentation: false,
                                   generateShapeProtocol: false,
@@ -100,10 +101,11 @@ public extension ServiceModelCodeGenerator {
                 createConversionFunction(originalTypeName: inputTypeName,
                                          derivedTypeName: pathTypeName,
                                          members: pathMembers,
+                                         modelTargetName: modelTargetName,
                                          fileBuilder: fileBuilder)
             }
             
-            pathTypeConversion = "encodable.as\(baseName)Model\(operationPrefix)Path()"
+            pathTypeConversion = "encodable.as\(modelTargetName)\(operationPrefix)Path()"
         } else {
             pathTypeName = "String"
             pathTypeConversion = "nil"
@@ -117,10 +119,10 @@ public extension ServiceModelCodeGenerator {
                                                    operationPrefix: String,
                                                    name: String,
                                                    generationType: ServiceModelCodeGenerator.ClientInputGenerationType,
+                                                   modelTargetName: String,
                                                    fileBuilder: FileBuilder) -> (queryTypeName: String, queryTypeConversion: String) {
         let queryTypeName: String
         let queryTypeConversion: String
-        let baseName = applicationDescription.baseName
         if !queryMembers.isEmpty {
             queryTypeName = "\(operationPrefix)Query"
             let structureDefinition = StructureDescription(
@@ -129,7 +131,7 @@ public extension ServiceModelCodeGenerator {
             
             if case .supportingStructures = generationType {
                 generateStructure(name: queryTypeName,
-                                  structureDescription: structureDefinition,
+                                  structureDescription: structureDefinition, modelTargetName: modelTargetName,
                                   fileBuilder: fileBuilder,
                                   includeVariableDocumentation: false,
                                   generateShapeProtocol: false,
@@ -138,10 +140,11 @@ public extension ServiceModelCodeGenerator {
                 createConversionFunction(originalTypeName: inputTypeName,
                                          derivedTypeName: queryTypeName,
                                          members: queryMembers,
+                                         modelTargetName: modelTargetName,
                                          fileBuilder: fileBuilder)
             }
             
-            queryTypeConversion = "encodable.as\(baseName)Model\(operationPrefix)Query()"
+            queryTypeConversion = "encodable.as\(modelTargetName)\(operationPrefix)Query()"
         } else {
             queryTypeName = "String"
             queryTypeConversion = "nil"
@@ -155,10 +158,10 @@ public extension ServiceModelCodeGenerator {
                                                   operationPrefix: String,
                                                   name: String,
                                                   generationType: ServiceModelCodeGenerator.ClientInputGenerationType,
+                                                  modelTargetName: String,
                                                   fileBuilder: FileBuilder) -> (bodyTypeName: String, bodyTypeConversion: String) {
         let bodyTypeName: String
         let bodyTypeConversion: String
-        let baseName = applicationDescription.baseName
         if !bodyMembers.isEmpty {
             bodyTypeName = "\(operationPrefix)Body"
             let structureDefinition = StructureDescription(
@@ -167,7 +170,7 @@ public extension ServiceModelCodeGenerator {
             
             if case .supportingStructures = generationType {
                 generateStructure(name: bodyTypeName,
-                                  structureDescription: structureDefinition,
+                                  structureDescription: structureDefinition, modelTargetName: modelTargetName,
                                   fileBuilder: fileBuilder,
                                   includeVariableDocumentation: false,
                                   generateShapeProtocol: false,
@@ -176,10 +179,11 @@ public extension ServiceModelCodeGenerator {
                 createConversionFunction(originalTypeName: inputTypeName,
                                          derivedTypeName: bodyTypeName,
                                          members: bodyMembers,
+                                         modelTargetName: modelTargetName,
                                          fileBuilder: fileBuilder)
             }
             
-            bodyTypeConversion = "encodable.as\(baseName)Model\(operationPrefix)Body()"
+            bodyTypeConversion = "encodable.as\(modelTargetName)\(operationPrefix)Body()"
         } else {
             bodyTypeName = "String"
             bodyTypeConversion = "nil"
@@ -193,11 +197,11 @@ public extension ServiceModelCodeGenerator {
                                                                operationPrefix: String,
                                                                name: String,
                                                                generationType: ServiceModelCodeGenerator.ClientInputGenerationType,
+                                                               modelTargetName: String,
                                                                fileBuilder: FileBuilder)
         -> (additionalHeadersTypeName: String, additionalHeadersTypeConversion: String) {
             let additionalHeadersTypeName: String
             let additionalHeadersTypeConversion: String
-            let baseName = applicationDescription.baseName
             if !additionalHeadersMembers.isEmpty {
                 additionalHeadersTypeName = "\(operationPrefix)AdditionalHeaders"
                 let structureDefinition = StructureDescription(
@@ -206,7 +210,7 @@ public extension ServiceModelCodeGenerator {
                 
                 if case .supportingStructures = generationType {
                     generateStructure(name: additionalHeadersTypeName,
-                                      structureDescription: structureDefinition,
+                                      structureDescription: structureDefinition, modelTargetName: modelTargetName,
                                       fileBuilder: fileBuilder,
                                       includeVariableDocumentation: false,
                                       generateShapeProtocol: false,
@@ -215,10 +219,11 @@ public extension ServiceModelCodeGenerator {
                     createConversionFunction(originalTypeName: inputTypeName,
                                              derivedTypeName: additionalHeadersTypeName,
                                              members: additionalHeadersMembers,
+                                             modelTargetName: modelTargetName,
                                              fileBuilder: fileBuilder)
                 }
                 
-                additionalHeadersTypeConversion = "encodable.as\(baseName)Model\(operationPrefix)AdditionalHeaders()"
+                additionalHeadersTypeConversion = "encodable.as\(modelTargetName)\(operationPrefix)AdditionalHeaders()"
             } else {
                 additionalHeadersTypeName = "String"
                 additionalHeadersTypeConversion = "nil"
@@ -239,6 +244,7 @@ public extension ServiceModelCodeGenerator {
     private func getBodyTypeNameAndConversion(inputDescription: OperationInputDescription, structureDefinition: StructureDescription,
                                               name: String, bodyMembers: [String: Member], inputTypeName: String,
                                               operationPrefix: String, generationType: ServiceModelCodeGenerator.ClientInputGenerationType,
+                                              modelTargetName: String,
                                               fileBuilder: FileBuilder) -> (bodyTypeName: String, bodyTypeConversion: String) {
         if let payloadAsMember = inputDescription.payloadAsMember {
             guard let payloadMember = structureDefinition.members[payloadAsMember] else {
@@ -257,7 +263,7 @@ public extension ServiceModelCodeGenerator {
         } else {
             return addBodyOperationHTTPRequestInput(
                 bodyMembers: bodyMembers, inputTypeName: inputTypeName, operationPrefix: operationPrefix, name: name,
-                generationType: generationType, fileBuilder: fileBuilder)
+                generationType: generationType, modelTargetName: modelTargetName, fileBuilder: fileBuilder)
         }
     }
     
@@ -268,6 +274,7 @@ public extension ServiceModelCodeGenerator {
                                                            operationPrefix: String,
                                                            name: String,
                                                            generationType: ServiceModelCodeGenerator.ClientInputGenerationType,
+                                                           modelTargetName: String,
                                                            fileBuilder: FileBuilder) {
         var unassignedMembers = structureDefinition.members
         var pathMembers: [String: Member] = [:]
@@ -301,19 +308,19 @@ public extension ServiceModelCodeGenerator {
         
         let (pathTypeName, pathTypeConversion) = addPathOperationHTTPRequestInput(
             pathMembers: pathMembers, inputTypeName: inputTypeName, operationPrefix: operationPrefix, name: name,
-            generationType: generationType, fileBuilder: fileBuilder)
+            generationType: generationType, modelTargetName: modelTargetName, fileBuilder: fileBuilder)
         let (queryTypeName, queryTypeConversion) = addQueryOperationHTTPRequestInput(
             queryMembers: queryMembers, inputTypeName: inputTypeName, operationPrefix: operationPrefix, name: name,
-            generationType: generationType, fileBuilder: fileBuilder)
+            generationType: generationType, modelTargetName: modelTargetName, fileBuilder: fileBuilder)
         
         let (bodyTypeName, bodyTypeConversion) = getBodyTypeNameAndConversion(
             inputDescription: inputDescription, structureDefinition: structureDefinition,
             name: name, bodyMembers: bodyMembers, inputTypeName: inputTypeName,
-            operationPrefix: operationPrefix, generationType: generationType, fileBuilder: fileBuilder)
+            operationPrefix: operationPrefix, generationType: generationType, modelTargetName: modelTargetName, fileBuilder: fileBuilder)
         
         let (additionalHeadersTypeName, additionalHeadersTypeConversion) = addAdditionalHeadersOperationHTTPRequestInput(
             additionalHeadersMembers: additionalHeadersMembers, inputTypeName: inputTypeName, operationPrefix: operationPrefix, name: name,
-            generationType: generationType, fileBuilder: fileBuilder)
+            generationType: generationType, modelTargetName: modelTargetName, fileBuilder: fileBuilder)
         
         let httpRequestInputTypes = HTTPRequestInputTypes(queryTypeName: queryTypeName, queryTypeConversion: queryTypeConversion,
                                                           pathTypeName: pathTypeName, pathTypeConversion: pathTypeConversion,
@@ -329,6 +336,7 @@ public extension ServiceModelCodeGenerator {
     func addOperationHTTPRequestInput(operation: String,
                                       operationDescription: OperationDescription,
                                       generationType: ClientInputGenerationType,
+                                      modelTargetName: String,
                                       fileBuilder: FileBuilder) {
         
         let name = operation.getNormalizedTypeName(forModel: model)
@@ -383,7 +391,7 @@ public extension ServiceModelCodeGenerator {
                 inputTypeName: inputTypeName,
                 operationPrefix: operationPrefix,
                 name: name,
-                generationType: generationType,
+                generationType: generationType, modelTargetName: modelTargetName,
                 fileBuilder: fileBuilder)
         }
     }

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelOperationsEnum.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelOperationsEnum.swift
@@ -23,7 +23,7 @@ public extension ServiceModelCodeGenerator {
     /**
      Generate an operation enumeration for the model.
      */
-    func generateModelOperationsEnum() {
+    func generateModelOperationsEnum(modelTargetName: String) {
         
         let fileBuilder = FileBuilder()
         let baseName = applicationDescription.baseName
@@ -35,7 +35,7 @@ public extension ServiceModelCodeGenerator {
         
         fileBuilder.appendLine("""
             // \(baseName)ModelOperations.swift
-            // \(baseName)Model
+            // \(modelTargetName)
             //
             
             import Foundation
@@ -48,7 +48,7 @@ public extension ServiceModelCodeGenerator {
         fileBuilder.appendLine("""
             
             /**
-             Operation enumeration for the \(baseName)Model.
+             Operation enumeration for the \(modelTargetName).
              */
             public enum \(baseName)ModelOperations: String, Hashable, CustomStringConvertible {
             """)
@@ -78,18 +78,19 @@ public extension ServiceModelCodeGenerator {
             addOperationHTTPRequestInput(operation: operation.key,
                                          operationDescription: operation.value,
                                          generationType: .supportingStructures,
+                                         modelTargetName: modelTargetName,
                                          fileBuilder: fileBuilder)
             
             addOperationHTTPRequestOutput(operation: operation.key,
                                           operationDescription: operation.value,
-                                          generationType: .supportingStructures,
+                                          generationType: .supportingStructures, modelTargetName: modelTargetName,
                                           fileBuilder: fileBuilder,
                                           alreadyEmittedTypes: &alreadyEmittedTypes)
         }
         
         let fileName = "\(baseName)ModelOperations.swift"
         let baseFilePath = applicationDescription.baseFilePath
-        fileBuilder.write(toFile: fileName, atFilePath: "\(baseFilePath)/Sources/\(baseName)Model")
+        fileBuilder.write(toFile: fileName, atFilePath: "\(baseFilePath)/Sources/\(modelTargetName)")
     }
     
     private func addOperationCases(sortedOperations: [(key: String, value: OperationDescription)], fileBuilder: FileBuilder) {

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelOperationsReporting.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateModelOperationsReporting.swift
@@ -23,7 +23,8 @@ public extension ServiceModelCodeGenerator {
     /**
      Generate an operation enumeration for the model.
      */
-    func generateOperationsReporting() {
+    func generateOperationsReporting(modelTargetName: String,
+                                     clientTargetName: String) {
         
         let fileBuilder = FileBuilder()
         let baseName = applicationDescription.baseName
@@ -35,12 +36,12 @@ public extension ServiceModelCodeGenerator {
         
         fileBuilder.appendLine("""
             // \(baseName)OperationsReporting.swift
-            // \(baseName)Client
+            // \(clientTargetName)
             //
             
             import Foundation
             import SmokeAWSCore
-            import \(baseName)Model
+            import \(modelTargetName)
             """)
         
         if case let .external(libraryImport: libraryImport, _) = customizations.validationErrorDeclaration {
@@ -50,7 +51,7 @@ public extension ServiceModelCodeGenerator {
         fileBuilder.appendLine("""
             
             /**
-             Operation reporting for the \(baseName)Model.
+             Operation reporting for the \(modelTargetName).
              */
             public struct \(baseName)OperationsReporting {
             """)
@@ -58,21 +59,24 @@ public extension ServiceModelCodeGenerator {
         let sortedOperations = model.operationDescriptions.sorted { (left, right) in left.key < right.key }
         
         fileBuilder.incIndent()
-        addOperationReportingParameters(fileBuilder: fileBuilder, baseName: baseName, sortedOperations: sortedOperations)
+        addOperationReportingParameters(fileBuilder: fileBuilder, baseName: baseName,
+                                        modelTargetName: modelTargetName, sortedOperations: sortedOperations)
         
         fileBuilder.appendEmptyLine()
-        addOperationReportingInitializer(fileBuilder: fileBuilder, baseName: baseName, sortedOperations: sortedOperations)
+        addOperationReportingInitializer(fileBuilder: fileBuilder, baseName: baseName,
+                                         modelTargetName: modelTargetName, sortedOperations: sortedOperations)
         
         fileBuilder.decIndent()
         fileBuilder.appendLine("}")
         
         let fileName = "\(baseName)OperationsReporting.swift"
         let baseFilePath = applicationDescription.baseFilePath
-        fileBuilder.write(toFile: fileName, atFilePath: "\(baseFilePath)/Sources/\(baseName)Client")
+        fileBuilder.write(toFile: fileName, atFilePath: "\(baseFilePath)/Sources/\(clientTargetName)")
     }
     
     private func addOperationReportingParameters(fileBuilder: FileBuilder, baseName: String,
-                                               sortedOperations: [(String, OperationDescription)]) {
+                                                 modelTargetName: String,
+                                                 sortedOperations: [(String, OperationDescription)]) {
         sortedOperations.forEach { (name, operation) in
             let variableName = getNormalizedVariableName(modelTypeName: name)
             
@@ -83,6 +87,7 @@ public extension ServiceModelCodeGenerator {
     }
     
     private func addOperationReportingInitializer(fileBuilder: FileBuilder, baseName: String,
+                                                  modelTargetName: String,
                                                   sortedOperations: [(String, OperationDescription)]) {
         fileBuilder.appendLine("public init(clientName: String, reportingConfiguration: SmokeAWSClientReportingConfiguration<\(baseName)ModelOperations>) {",
                                postInc: true)

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+shapeProtocol.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+shapeProtocol.swift
@@ -20,9 +20,9 @@ import ServiceModelCodeGeneration
 import ServiceModelEntities
 
 internal extension ServiceModelCodeGenerator {
-    func addShapeProtocol(name: String, fileBuilder: FileBuilder,
+    func addShapeProtocol(name: String, modelTargetName: String,
+                          fileBuilder: FileBuilder,
                           structureElements: StructureElements) {
-        let baseName = applicationDescription.baseName
         // add conformance to Equatable
         fileBuilder.appendLine("""
             
@@ -51,14 +51,14 @@ internal extension ServiceModelCodeGenerator {
         
         fileBuilder.appendLine("""
             
-                func as\(baseName)Model\(name)()\(failPostix) -> \(baseName)Model.\(name)
+                func as\(modelTargetName)\(name)()\(failPostix) -> \(modelTargetName).\(name)
             }
             """)
     }
 
-    func addShapeDefaultFunctions(name: String, fileBuilder: FileBuilder,
+    func addShapeDefaultFunctions(name: String, modelTargetName: String,
+                                  fileBuilder: FileBuilder,
                                   structureElements: StructureElements) {
-        let baseName = applicationDescription.baseName
         let willConversionFail = willShapeConversionFail(fieldName: name, alreadySeenShapes: [])
         let failPostix = willConversionFail ? " throws" : ""
         
@@ -67,7 +67,7 @@ internal extension ServiceModelCodeGenerator {
             
             public extension \(name)Shape {
             
-                func as\(baseName)Model\(name)()\(failPostix) -> \(baseName)Model.\(name) {
+                func as\(modelTargetName)\(name)()\(failPostix) -> \(modelTargetName).\(name) {
                     if let modelInstance = self as? \(name) {
                         // don't need to convert, already can be serialized
                         return modelInstance

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+validationFunctions.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+validationFunctions.swift
@@ -87,6 +87,7 @@ extension ServiceModelCodeGenerator {
 
     func createFieldValidation<ConstraintType>(fileBuilder: FileBuilder,
                                                name: String,
+                                               modelTargetName: String,
                                                isListWithInnerType: String?,
                                                rangeValidation: (String, String, String, FileBuilder, ConstraintType) -> (),
                                                regexConstraint: String?,
@@ -94,19 +95,18 @@ extension ServiceModelCodeGenerator {
         let typeName: String
         let extensionName: String
         let extensionDeclaration: String
-        let baseName = applicationDescription.baseName
         if let isListWithInnerType = isListWithInnerType {
             typeName = isListWithInnerType.getNormalizedTypeName(forModel: model)
             extensionName = name.getNormalizedTypeName(forModel: model)
             if typeName.isBuiltinType {
                 extensionDeclaration = "Array where Element == \(typeName)"
             } else {
-                extensionDeclaration = "Array where Element == \(baseName)Model.\(typeName)"
+                extensionDeclaration = "Array where Element == \(modelTargetName).\(typeName)"
             }
         } else {
             typeName = name.getNormalizedTypeName(forModel: model)
             extensionName = typeName
-            extensionDeclaration = "\(baseName)Model.\(typeName)"
+            extensionDeclaration = "\(modelTargetName).\(typeName)"
         }
         
         // if there are constraints


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Support custom target names. Previously the generator expected the targets to be `<baseName>Model` and `<baseName>Client`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
