### PR TITLE
Associate a OverridesType with a ServiceModel type.

### DIFF
--- a/Sources/ServiceModelCodeGeneration/ModelClientDelegate.swift
+++ b/Sources/ServiceModelCodeGeneration/ModelClientDelegate.swift
@@ -76,6 +76,7 @@ public enum ClientEntityType {
  from the Service Model.
  */
 public protocol ModelClientDelegate {
+    associatedtype ModelType: ServiceModel
     associatedtype TargetSupportType
     
     /// The type of client being generated.
@@ -93,7 +94,7 @@ public protocol ModelClientDelegate {
         - delegate: the delegate being used.
         - fileBuilder: The FileBuilder to output to.
      */
-    func addCustomFileHeader(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    func addCustomFileHeader(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                              delegate: Self,
                              fileBuilder: FileBuilder,
                              fileType: ClientFileType)
@@ -106,7 +107,7 @@ public protocol ModelClientDelegate {
         - delegate: the delegate being used.
         - fileBuilder: The FileBuilder to output to.
      */
-    func addTypeDescription(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    func addTypeDescription(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                             delegate: Self,
                             fileBuilder: FileBuilder,
                             entityType: ClientEntityType)
@@ -120,7 +121,7 @@ public protocol ModelClientDelegate {
         - fileBuilder: The FileBuilder to output to.
         - sortedOperations: A list of sorted operations from the current model.
      */
-    func addCommonFunctions(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    func addCommonFunctions(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                             delegate: Self,
                             fileBuilder: FileBuilder,
                             sortedOperations: [(String, OperationDescription)],
@@ -139,7 +140,7 @@ public protocol ModelClientDelegate {
         - functionInputType: the input type to the operation.
         - functionOutputType: the output type for the operation.
      */
-    func addOperationBody(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    func addOperationBody(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                           delegate: Self,
                           fileBuilder: FileBuilder,
                           invokeType: InvokeType,

--- a/Sources/ServiceModelCodeGeneration/ServiceModelCodeGenerator.swift
+++ b/Sources/ServiceModelCodeGeneration/ServiceModelCodeGenerator.swift
@@ -37,11 +37,11 @@ public struct ModelAndClientTargetSupport: ModelTargetSupport, ClientTargetSuppo
 }
 
 /// A code generator that uses a Service Model
-public struct ServiceModelCodeGenerator<TargetSupportType> {
-    public let model: ServiceModel
+public struct ServiceModelCodeGenerator<ModelType: ServiceModel, TargetSupportType> {
+    public let model: ModelType
     public let applicationDescription: ApplicationDescription
     public let customizations: CodeGenerationCustomizations
-    public let modelOverride: ModelOverride?
+    public let modelOverride: ModelOverride<ModelType.OverridesType>?
     public let targetSupport: TargetSupportType
     
     /**
@@ -56,10 +56,10 @@ public struct ServiceModelCodeGenerator<TargetSupportType> {
         - baseFilePath: The file path of the generated package.
         - applicationDescription: A description of the application being created.
      */
-    public init(model: ServiceModel,
+    public init(model: ModelType,
                 applicationDescription: ApplicationDescription,
                 customizations: CodeGenerationCustomizations,
-                modelOverride: ModelOverride?,
+                modelOverride: ModelOverride<ModelType.OverridesType>?,
                 targetSupport: TargetSupportType) {
         self.model = model
         self.applicationDescription = applicationDescription

--- a/Sources/ServiceModelEntities/ModelOverride.swift
+++ b/Sources/ServiceModelEntities/ModelOverride.swift
@@ -17,8 +17,12 @@
 
 import Foundation
 
+public struct NoModelTypeOverrides: Codable {
+    
+}
+
 /// Data model for the ModelOverride input file
-public struct ModelOverride: Codable {
+public struct ModelOverride<ModelTypeOverridesType: Codable>: Codable {
     /// attributes of these types should match the original case.
     public let matchCase: Set<String>?
     /// attributes of these types should match the original case.
@@ -50,6 +54,8 @@ public struct ModelOverride: Codable {
     public let ignoreRequestHeaders: Set<String>?
     /// overrides the default value used for an enumeration
     public let defaultEnumerationValueOverride: [String: String]?
+    /// overrides that are specific to a particular model type
+    public let modelTypeOverrides: ModelTypeOverridesType?
     
     public init(matchCase: Set<String>? = nil,
                 enumerations: EnumerationNaming? = nil,
@@ -64,7 +70,8 @@ public struct ModelOverride: Codable {
                 ignoreOperations: Set<String>? = nil,
                 ignoreResponseHeaders: Set<String>? = nil,
                 ignoreRequestHeaders: Set<String>? = nil,
-                defaultEnumerationValueOverride: [String: String]? = nil) {
+                defaultEnumerationValueOverride: [String: String]? = nil,
+                modelTypeOverrides: ModelTypeOverridesType? = nil) {
         self.matchCase = matchCase
         self.enumerations = enumerations
         self.fieldRawTypeOverride = fieldRawTypeOverride
@@ -79,6 +86,7 @@ public struct ModelOverride: Codable {
         self.ignoreResponseHeaders = ignoreResponseHeaders
         self.ignoreRequestHeaders = ignoreRequestHeaders
         self.defaultEnumerationValueOverride = defaultEnumerationValueOverride
+        self.modelTypeOverrides = modelTypeOverrides
     }
     
     public func getCodingKeyOverride(attributeName: String, inType: String?) -> String? {

--- a/Sources/ServiceModelEntities/ServiceModel.swift
+++ b/Sources/ServiceModelEntities/ServiceModel.swift
@@ -31,6 +31,8 @@ public enum ServiceModelError: Error {
  Protocol for a Service Model description.
  */
 public protocol ServiceModel {
+    associatedtype OverridesType: Codable = NoModelTypeOverrides
+    
     var serviceInformation: ServiceInformation? { get }
     var serviceDescriptions: [String: ServiceDescription] { get }
     var structureDescriptions: [String: StructureDescription] { get }
@@ -44,20 +46,20 @@ public protocol ServiceModel {
      Initialize an instance of this ServiceModel type from a data instance
      that represents that type.
      */
-    static func create(data: Data, modelFormat: ModelFormat, modelOverride: ModelOverride?) throws -> Self
+    static func create(data: Data, modelFormat: ModelFormat, modelOverride: ModelOverride<OverridesType>?) throws -> Self
     
     /**
      Initialize an instance of this ServiceModel type from a data instance
      that represents that type.
      */
-    static func create(dataList: [Data], modelFormat: ModelFormat, modelOverride: ModelOverride?) throws -> Self
+    static func create(dataList: [Data], modelFormat: ModelFormat, modelOverride: ModelOverride<OverridesType>?) throws -> Self
 }
 
 public extension ServiceModel {
     // Provide default value for backwards compatibility
     var serviceInformation: ServiceInformation? { nil }
 
-    static func create(dataList: [Data], modelFormat: ModelFormat, modelOverride: ModelOverride?) throws -> Self {
+    static func create(dataList: [Data], modelFormat: ModelFormat, modelOverride: ModelOverride<OverridesType>?) throws -> Self {
         throw ServiceModelError.notImplementedException
     }
 }

--- a/Sources/ServiceModelEntities/String+nameConversions.swift
+++ b/Sources/ServiceModelEntities/String+nameConversions.swift
@@ -32,7 +32,7 @@ public extension String {
      The normalized name for a type; either a specified type mapping
      from the provided service model or this string startingWithUppercase.
      */
-    func getNormalizedTypeName(forModel model: ServiceModel) -> String {
+    func getNormalizedTypeName<ModelType: ServiceModel>(forModel model: ModelType) -> String {
         // if there is a mapping for this name
         if let mappedName = model.typeMappings[self] {
             return mappedName

--- a/Sources/ServiceModelGenerate/ClientProtocolDelegate.swift
+++ b/Sources/ServiceModelGenerate/ClientProtocolDelegate.swift
@@ -23,7 +23,7 @@ import ServiceModelEntities
  A ModelClientDelegate that can be used to generate a
  Client protocol from a Service Model.
  */
-public struct ClientProtocolDelegate<TargetSupportType>: ModelClientDelegate
+public struct ClientProtocolDelegate<ModelType: ServiceModel, TargetSupportType>: ModelClientDelegate
 where TargetSupportType: ModelTargetSupport & ClientTargetSupport {
     public let clientType: ClientType
     public let baseName: String
@@ -50,21 +50,21 @@ where TargetSupportType: ModelTargetSupport & ClientTargetSupport {
         self.minimumCompilerSupport = minimumCompilerSupport
     }
     
-    public func addTypeDescription(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    public func addTypeDescription(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                    delegate: Self,
                                    fileBuilder: FileBuilder,
                                    entityType: ClientEntityType) {
         fileBuilder.appendLine(self.typeDescription)
     }
     
-    public func addCustomFileHeader(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    public func addCustomFileHeader(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                     delegate: Self,
                                     fileBuilder: FileBuilder,
                                     fileType: ClientFileType) {
         // no custom file header
     }
     
-    public func addCommonFunctions(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    public func addCommonFunctions(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                    delegate: Self,
                                    fileBuilder: FileBuilder,
                                    sortedOperations: [(String, OperationDescription)],
@@ -125,7 +125,7 @@ where TargetSupportType: ModelTargetSupport & ClientTargetSupport {
         }
     }
     
-    public func addOperationBody(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    public func addOperationBody(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                  delegate: Self,
                                  fileBuilder: FileBuilder, invokeType: InvokeType,
                                  operationName: String,

--- a/Sources/ServiceModelGenerate/MockClientDelegate.swift
+++ b/Sources/ServiceModelGenerate/MockClientDelegate.swift
@@ -23,7 +23,7 @@ import ServiceModelEntities
  A ModelClientDelegate that can be used to generate a
  mock or throwing test client from a Service Model.
  */
-public struct MockClientDelegate<TargetSupportType>: ModelClientDelegate {
+public struct MockClientDelegate<ModelType: ServiceModel, TargetSupportType>: ModelClientDelegate {
     public let baseName: String
     public let isThrowingMock: Bool
     public let clientType: ClientType
@@ -77,7 +77,7 @@ public struct MockClientDelegate<TargetSupportType>: ModelClientDelegate {
                                   conformingProtocolNames: conformingProtocolNames)
     }
     
-    public func addTypeDescription(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    public func addTypeDescription(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                    delegate: Self,
                                    fileBuilder: FileBuilder,
                                    entityType: ClientEntityType) {
@@ -116,7 +116,7 @@ public struct MockClientDelegate<TargetSupportType>: ModelClientDelegate {
             """)
     }
     
-    public func addCustomFileHeader(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    public func addCustomFileHeader(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                     delegate: Self,
                                     fileBuilder: FileBuilder,
                                     fileType: ClientFileType) {
@@ -143,7 +143,7 @@ public struct MockClientDelegate<TargetSupportType>: ModelClientDelegate {
         fileBuilder.appendLine("\(variableName): \(name.startingWithUppercase)FunctionType? = nil\(postfix)")
     }
     
-    public func addCommonFunctions(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    public func addCommonFunctions(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                    delegate: Self,
                                    fileBuilder: FileBuilder,
                                    sortedOperations: [(String, OperationDescription)],
@@ -265,7 +265,7 @@ public struct MockClientDelegate<TargetSupportType>: ModelClientDelegate {
                 """)
     }
     
-    public func addOperationBody(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    public func addOperationBody(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                  delegate: Self,
                                  fileBuilder: FileBuilder,
                                  invokeType: InvokeType,
@@ -291,7 +291,7 @@ public struct MockClientDelegate<TargetSupportType>: ModelClientDelegate {
         }
     }
     
-    private func delegateMockImplementationCall(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    private func delegateMockImplementationCall(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                                 functionPrefix: String, functionInfix: String,
                                                 fileBuilder: FileBuilder, hasInput: Bool,
                                                 functionOutputType: String?, operationName: String) {
@@ -338,7 +338,7 @@ public struct MockClientDelegate<TargetSupportType>: ModelClientDelegate {
         }
     }
     
-    private func delegateAsyncOnlyMockImplementationCall(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    private func delegateAsyncOnlyMockImplementationCall(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                                          fileBuilder: FileBuilder, hasInput: Bool,
                                                          functionOutputType: String?, operationName: String) {
         let variableName = operationName.upperToLowerCamelCase
@@ -363,7 +363,7 @@ public struct MockClientDelegate<TargetSupportType>: ModelClientDelegate {
         }
     }
     
-    private func addMockClientOperationBody(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    private func addMockClientOperationBody(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                             fileBuilder: FileBuilder, hasInput: Bool,
                                             functionOutputType: String?, invokeType: InvokeType,
                                             protocolTypeName: String, operationName: String) {
@@ -425,7 +425,7 @@ public struct MockClientDelegate<TargetSupportType>: ModelClientDelegate {
         fileBuilder.appendLine("}", preDec: true)
     }
     
-    private func delegateMockThrowingImplementationCall(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    private func delegateMockThrowingImplementationCall(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                                         functionPrefix: String, functionInfix: String,
                                                         fileBuilder: FileBuilder, hasInput: Bool,
                                                         functionOutputType: String?, operationName: String) {
@@ -472,7 +472,7 @@ public struct MockClientDelegate<TargetSupportType>: ModelClientDelegate {
         }
     }
     
-    private func delegateAsyncOnlyMockThrowingImplementationCall(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    private func delegateAsyncOnlyMockThrowingImplementationCall(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                                                  fileBuilder: FileBuilder, hasInput: Bool,
                                                                  functionOutputType: String?, operationName: String) {
         let variableName = operationName.upperToLowerCamelCase
@@ -497,7 +497,7 @@ public struct MockClientDelegate<TargetSupportType>: ModelClientDelegate {
         }
     }
     
-    private func addThrowingClientOperationBody(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    private func addThrowingClientOperationBody(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                                 fileBuilder: FileBuilder, hasInput: Bool, functionOutputType: String?,
                                                 invokeType: InvokeType, operationName: String) {
         let functionPrefix: String

--- a/Sources/ServiceModelGenerate/ModelClientDelegate+common.swift
+++ b/Sources/ServiceModelGenerate/ModelClientDelegate+common.swift
@@ -22,7 +22,7 @@ import ServiceModelEntities
 public typealias SpecificErrorBehaviour = (retriableErrors: [String], unretriableErrors: [String], defaultBehaviorErrorsCount: Int)
 
 public extension ModelClientDelegate where TargetSupportType: ModelTargetSupport {
-    func getSpecificErrors(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>, baseName: String) -> SpecificErrorBehaviour {
+    func getSpecificErrors(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>, baseName: String) -> SpecificErrorBehaviour {
         let sortedErrors = codeGenerator.getSortedErrors(allErrorTypes: codeGenerator.model.errorTypes)
         
         var retriableErrors: [String] = []
@@ -54,7 +54,7 @@ public extension ModelClientDelegate where TargetSupportType: ModelTargetSupport
 }
 
 public extension ModelClientDelegate {
-    func addTypedErrorRetriableExtension(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    func addTypedErrorRetriableExtension(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                          fileBuilder: FileBuilder, baseName: String,
                                          specificErrorBehaviour: SpecificErrorBehaviour) {
         let errorType = "\(baseName)Error"
@@ -136,7 +136,7 @@ public extension ModelClientDelegate {
         fileBuilder.decIndent()
     }
     
-    func addErrorRetriableExtension(codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+    func addErrorRetriableExtension(codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                     fileBuilder: FileBuilder, baseName: String) {
         let errorType = "\(baseName)Error"
                 
@@ -155,7 +155,7 @@ public extension ModelClientDelegate {
     }
     
     func addClientOperationMetricsParameters(fileBuilder: FileBuilder, baseName: String,
-                                             codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+                                             codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                              sortedOperations: [(String, OperationDescription)],
                                              entityType: ClientEntityType) {
         guard entityType.isGenerator || entityType.isClientImplementation else {
@@ -228,7 +228,7 @@ public extension ModelClientDelegate {
     func addClientGeneratorWithTraceContext(
             fileBuilder: FileBuilder,
             baseName: String,
-            codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+            codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
             targetsAPIGateway: Bool,
             contentType: String) {
         guard case .struct(let clientName, _, _) = clientType else {
@@ -256,7 +256,7 @@ public extension ModelClientDelegate {
     func addClientGeneratorWithLogger(
             fileBuilder: FileBuilder,
             baseName: String,
-            codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+            codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
             targetsAPIGateway: Bool,
             invocationTraceContext: InvocationTraceContextDeclaration,
             contentType: String) {
@@ -282,7 +282,7 @@ public extension ModelClientDelegate {
     }
     
     func addClientOperationMetricsInitializerBody(fileBuilder: FileBuilder, baseName: String,
-                                                  codeGenerator: ServiceModelCodeGenerator<TargetSupportType>,
+                                                  codeGenerator: ServiceModelCodeGenerator<ModelType, TargetSupportType>,
                                                   sortedOperations: [(String, OperationDescription)],
                                                   entityType: ClientEntityType, initializerType: InitializerType,
                                                   inputPrefix: String) {

--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateClient.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+generateClient.swift
@@ -50,7 +50,7 @@ public extension ServiceModelCodeGenerator where TargetSupportType: ModelTargetS
      */
     func generateClient<DelegateType: ModelClientDelegate>(delegate: DelegateType, fileType: ClientFileType,
                                                            defaultTraceContextType: DefaultTraceContextType)
-    where DelegateType.TargetSupportType == TargetSupportType {
+    where DelegateType.TargetSupportType == TargetSupportType, DelegateType.ModelType == ModelType {
         let fileBuilder = FileBuilder()
         let clientTargetName = self.targetSupport.clientTargetName
         
@@ -184,7 +184,7 @@ public extension ServiceModelCodeGenerator where TargetSupportType: ModelTargetS
     private func generateClient<DelegateType: ModelClientDelegate>(
         delegate: DelegateType, entityType: ClientEntityType,
         genericType: Bool, fileBuilder: FileBuilder)
-    where DelegateType.TargetSupportType == TargetSupportType {
+    where DelegateType.TargetSupportType == TargetSupportType, DelegateType.ModelType == ModelType {
         let typeName = getTypeName(delegate: delegate, entityType: entityType, genericType: genericType)
         
         let typeDecaration: String
@@ -437,7 +437,7 @@ public extension ServiceModelCodeGenerator where TargetSupportType: ModelTargetS
         invokeType: InvokeType, forTypeAlias: Bool,
         operationSignature: OperationSignature,
         entityType: ClientEntityType)
-    where DelegateType.TargetSupportType == TargetSupportType {
+    where DelegateType.TargetSupportType == TargetSupportType, DelegateType.ModelType == ModelType {
         let functionName: String
         if !forTypeAlias {
             fileBuilder.appendLine(" */")
@@ -504,7 +504,7 @@ public extension ServiceModelCodeGenerator where TargetSupportType: ModelTargetS
         delegate: DelegateType,
         operationInvokeType: OperationInvokeType, forTypeAlias: Bool,
         entityType: ClientEntityType, prefixLine: String? = nil, postfixLine: String? = nil)
-    where DelegateType.TargetSupportType == TargetSupportType {
+    where DelegateType.TargetSupportType == TargetSupportType, DelegateType.ModelType == ModelType {
         // OperationInvokeType.syncFunctionForNoAsyncAwaitSupport is only an internal invoke state
         // for legacy support so we ignore it other than for where it is necessary
         let invokeType: InvokeType

--- a/Sources/ServiceModelGenerate/ServiceModelGenerate.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelGenerate.swift
@@ -75,9 +75,9 @@ public struct ServiceModelGenerate {
         modelFilePath: String,
         customizations: CodeGenerationCustomizations,
         applicationDescription: ApplicationDescription,
-        modelOverride: ModelOverride?,
+        modelOverride: ModelOverride<ModelType.OverridesType>?,
         targetSupport: TargetSupportType,
-        generatorFunction: (ServiceModelCodeGenerator<TargetSupportType>, ModelType) throws -> ()) throws
+        generatorFunction: (ServiceModelCodeGenerator<ModelType, TargetSupportType>, ModelType) throws -> ()) throws
     -> ModelType {
         let (data, modelFormat) = getModelDataForFilePath(modelFilePath: modelFilePath)
         
@@ -99,8 +99,8 @@ public struct ServiceModelGenerate {
         modelFilePath: String,
         customizations: CodeGenerationCustomizations,
         applicationDescription: ApplicationDescription,
-        modelOverride: ModelOverride?,
-        generatorFunction: (ServiceModelCodeGenerator<ModelAndClientTargetSupport>, ModelType) throws -> ()) throws
+        modelOverride: ModelOverride<ModelType.OverridesType>?,
+        generatorFunction: (ServiceModelCodeGenerator<ModelType, ModelAndClientTargetSupport>, ModelType) throws -> ()) throws
     -> ModelType {
         return try generateFromModel(modelFilePath: modelFilePath,
                                      customizations: customizations,
@@ -125,9 +125,9 @@ public struct ServiceModelGenerate {
         modelFilePaths: [String],
         customizations: CodeGenerationCustomizations,
         applicationDescription: ApplicationDescription,
-        modelOverride: ModelOverride?,
+        modelOverride: ModelOverride<ModelType.OverridesType>?,
         targetSupport: TargetSupportType,
-        generatorFunction: (ServiceModelCodeGenerator<TargetSupportType>, ModelType) throws -> ()) throws
+        generatorFunction: (ServiceModelCodeGenerator<ModelType, TargetSupportType>, ModelType) throws -> ()) throws
     -> ModelType {
         var modelFormat: ModelFormat?
         let dataList: [Data] = modelFilePaths.map { modelFilePath in
@@ -163,8 +163,8 @@ public struct ServiceModelGenerate {
         modelFilePaths: [String],
         customizations: CodeGenerationCustomizations,
         applicationDescription: ApplicationDescription,
-        modelOverride: ModelOverride?,
-        generatorFunction: (ServiceModelCodeGenerator<ModelAndClientTargetSupport>, ModelType) throws -> ()) throws
+        modelOverride: ModelOverride<ModelType.OverridesType>?,
+        generatorFunction: (ServiceModelCodeGenerator<ModelType, ModelAndClientTargetSupport>, ModelType) throws -> ()) throws
     -> ModelType {
         return try generateFromModel(modelFilePaths: modelFilePaths,
                                      customizations: customizations,
@@ -191,9 +191,9 @@ public struct ServiceModelGenerate {
         fileExtension: String,
         customizations: CodeGenerationCustomizations,
         applicationDescription: ApplicationDescription,
-        modelOverride: ModelOverride?,
+        modelOverride: ModelOverride<ModelType.OverridesType>?,
         targetSupport: TargetSupportType,
-        generatorFunction: (ServiceModelCodeGenerator<TargetSupportType>, ModelType) throws -> ()) throws
+        generatorFunction: (ServiceModelCodeGenerator<ModelType, TargetSupportType>, ModelType) throws -> ()) throws
     -> ModelType {
         let dataList = try getDataListForModelFiles(atPath: modelDirectoryPath, fileExtension: fileExtension)
         
@@ -218,8 +218,8 @@ public struct ServiceModelGenerate {
         fileExtension: String,
         customizations: CodeGenerationCustomizations,
         applicationDescription: ApplicationDescription,
-        modelOverride: ModelOverride?,
-        generatorFunction: (ServiceModelCodeGenerator<ModelAndClientTargetSupport>, ModelType) throws -> ()) throws
+        modelOverride: ModelOverride<ModelType.OverridesType>?,
+        generatorFunction: (ServiceModelCodeGenerator<ModelType, ModelAndClientTargetSupport>, ModelType) throws -> ()) throws
     -> ModelType {
         return try generateFromModel(modelDirectoryPath: modelDirectoryPath,
                                      fileExtension: fileExtension,
@@ -247,9 +247,9 @@ public struct ServiceModelGenerate {
         fileExtension: String,
         customizations: CodeGenerationCustomizations,
         applicationDescription: ApplicationDescription,
-        modelOverride: ModelOverride?,
+        modelOverride: ModelOverride<ModelType.OverridesType>?,
         targetSupport: TargetSupportType,
-        generatorFunction: (ServiceModelCodeGenerator<TargetSupportType>, ModelType) throws -> ()) throws
+        generatorFunction: (ServiceModelCodeGenerator<ModelType, TargetSupportType>, ModelType) throws -> ()) throws
     -> ModelType {
         let dataList = try modelDirectoryPaths.map { path in
             try getDataListForModelFiles(atPath: path, fileExtension: fileExtension)
@@ -276,8 +276,8 @@ public struct ServiceModelGenerate {
         fileExtension: String,
         customizations: CodeGenerationCustomizations,
         applicationDescription: ApplicationDescription,
-        modelOverride: ModelOverride?,
-        generatorFunction: (ServiceModelCodeGenerator<ModelAndClientTargetSupport>, ModelType) throws -> ()) throws
+        modelOverride: ModelOverride<ModelType.OverridesType>?,
+        generatorFunction: (ServiceModelCodeGenerator<ModelType, ModelAndClientTargetSupport>, ModelType) throws -> ()) throws
     -> ModelType {
         return try generateFromModel(modelDirectoryPaths: modelDirectoryPaths,
                                      fileExtension: fileExtension,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Associate a OverridesType with a ServiceModel type. This will allow a particular model type - such as `OpenAPIServiceModel` or `MyCustomServiceModel` - to pass into the model decode process override parameters that are specific to that service model type.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
