### PR TITLE
Add the ability to generate Swift Concurrency implementations.

### DIFF
--- a/Sources/ServiceModelCodeGeneration/ModelClientDelegate.swift
+++ b/Sources/ServiceModelCodeGeneration/ModelClientDelegate.swift
@@ -86,6 +86,8 @@ public protocol ModelClientDelegate {
 public enum ClientType {
     /// A protocol with the specified name
     case `protocol`(name: String)
+    /// A protocol with the specified name that also conforms to the specified protocol
+    case `protocolWithConformance`(name: String, conformingProtocolName: String)
     /// A struct with the specified name and conforming to the specified protocol
     case `struct`(name: String, genericParameters: [(typeName: String, conformingTypeName: String?)], conformingProtocolName: String)
 }
@@ -111,6 +113,7 @@ public struct AsyncResultType {
 public enum InvokeType: String {
     case sync = "Sync"
     case async = "Async"
+    case asyncFunction = "AsyncFunction"
 }
 
 public extension ModelClientDelegate {

--- a/Sources/ServiceModelCodeGeneration/ModelClientDelegate.swift
+++ b/Sources/ServiceModelCodeGeneration/ModelClientDelegate.swift
@@ -86,7 +86,7 @@ public protocol ModelClientDelegate {
 public enum ClientType {
     /// A protocol with the specified name
     case `protocol`(name: String)
-    /// A protocol with the specified name that also conforms to the specified protocol
+    /// A protocol with the specified name, also conforming to the specified protocol
     case `protocolWithConformance`(name: String, conformingProtocolName: String)
     /// A struct with the specified name and conforming to the specified protocol
     case `struct`(name: String, genericParameters: [(typeName: String, conformingTypeName: String?)], conformingProtocolName: String)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds support for Swift Concurrency based implementations in a backwards-compatible manner.

These changes only relate to the `service-model-swift-code-generate-2.x` branch - which is only used to generate the `smoke-aws` package and (in conjunction with changes to` smoke-aws-generate`) result in

https://github.com/amzn/smoke-aws/compare/main...on_swift_concurrency_threads

**(baseName)ClientProtocolV2**: a new protocol that just contains Swift Concurrency (Async/Await) based APIs
**(baseName)ClientProtocol**: an existing protocol that now conforms to the new `(baseName)ClientProtocolV2` protocol. There are no other changes to this protocol.
**(baseName)ClientProtocol+async**: existing extensions to the existing `(baseName)ClientProtocol` that provide Swift Concurrency (Async/Await) based APIs by delegating to the callback-based async APIs in the existing protocol. There are no changes to these extensions but they will now satisfy the conformance to the `(baseName)ClientProtocolV2` by providing a *default* implementation unless a conforming type provides one itself.
**AWS(baseName)Client**: an existing type that conforms to the `(baseName)ClientProtocol`, adding Swift Concurrency based implementations that call into the Swift Concurrency based APIs of `smoke-http`. Because these APIs are now implemented within this type, they will *override the default* implementations in the extension of the protocol.
**Mock(baseName)ClientV2** and **Throwing(baseName)ClientV2**: Mock implementations that conform to the `(baseName)ClientProtocolV2` protocol. These implementations just provide the ability to mock the Swift Concurrency (Async/Await) based APIs and therefore do not require passing an `EventLoop` to their initializer.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
