### PR TITLE
Add the ability to generate Swift Concurrency implementations.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,23 @@
+name: build
+
+on:
+  push:
+    branches: [ main, service-model-swift-code-generate-2.x, service-model-swift-code-generate-1.x ]
+  pull_request:
+    branches: [ main, service-model-swift-code-generate-2.x, service-model-swift-code-generate-1.x ]
+      
+jobs:
+  Build:
+    name: Swift ${{ matrix.swift }} on ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+        swift: ["5.7.2", "5.6.3", "5.5.3"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: swift-actions/setup-swift@v1.21.0
+        with:
+          swift-version: ${{ matrix.swift }}
+      - uses: actions/checkout@v2
+      - name: Build
+        run: swift build -c release

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,7 +12,21 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        swift: ["5.7.2", "5.6.3", "5.5.3"]
+        swift: ["5.7.2"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: swift-actions/setup-swift@v1.21.0
+        with:
+          swift-version: ${{ matrix.swift }}
+      - uses: actions/checkout@v2
+      - name: Build
+        run: swift build -c release
+  Build20:
+    name: Swift ${{ matrix.swift }} on ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        swift: ["5.6.3", "5.5.3"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: swift-actions/setup-swift@v1.21.0

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 <p align="center">
-<a href="https://travis-ci.com/amzn/service-model-swift-code-generate">
-<img src="https://travis-ci.com/amzn/service-model-swift-code-generate.svg?branch=master" alt="Build - Master Branch">
+<a href="https://github.com/amzn/service-model-swift-code-generate/actions">
+<img src="https://github.com/amzn/service-model-swift-code-generate/actions/workflows/swift.yml/badge.svg?branch=service-model-swift-code-generate-2.x" alt="Build - service-model-swift-code-generate-2.x Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.1|5.2|5.3-orange.svg?style=flat" alt="Swift 5.1, 5.2 and 5.3 Tested">
+<img src="https://img.shields.io/badge/swift-5.5|5.6|5.7-orange.svg?style=flat" alt="Swift 5.5, 5.6 and 5.7 Tested">
 </a>
-<img src="https://img.shields.io/badge/ubuntu-16.04|18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 16.04, 18.04 and 20.04 Tested">
-<img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">
-<img src="https://img.shields.io/badge/AmazonLinux-2-yellow.svg?style=flat" alt="Amazon Linux 2 Tested">
 <a href="https://gitter.im/SmokeServerSide">
 <img src="https://img.shields.io/badge/chat-on%20gitter-ee115e.svg?style=flat" alt="Join the Smoke Server Side community on gitter">
 </a>

--- a/Sources/ServiceModelCodeGeneration/ModelClientDelegate.swift
+++ b/Sources/ServiceModelCodeGeneration/ModelClientDelegate.swift
@@ -86,6 +86,8 @@ public protocol ModelClientDelegate {
 public enum ClientType {
     /// A protocol with the specified name
     case `protocol`(name: String)
+    /// A protocol with the specified name, also conforming to the specified protocol
+    case `protocolWithConformance`(name: String, conformingProtocolName: String)
     /// A struct with the specified name and conforming to the specified protocol
     case `struct`(name: String, genericParameters: [(typeName: String, conformingTypeName: String?)], conformingProtocolName: String)
 }
@@ -111,6 +113,7 @@ public struct AsyncResultType {
 public enum InvokeType: String {
     case sync = "Sync"
     case async = "Async"
+    case asyncFunction = "AsyncFunction"
 }
 
 public extension ModelClientDelegate {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds support for Swift Concurrency based implementations in a backwards-compatible manner.

These changes only relate to the `service-model-swift-code-generate-2.x` branch - which is only used to generate the `smoke-aws` package and (in conjunction with changes to` smoke-aws-generate`) result in

https://github.com/amzn/smoke-aws/compare/main...on_swift_concurrency_threads

**(baseName)ClientProtocolV2**: a new protocol that just contains Swift Concurrency (Async/Await) based APIs
**(baseName)ClientProtocol**: an existing protocol that now conforms to the new `(baseName)ClientProtocolV2` protocol. There are no other changes to this protocol.
**(baseName)ClientProtocol+async**: existing extensions to the existing `(baseName)ClientProtocol` that provide Swift Concurrency (Async/Await) based APIs by delegating to the callback-based async APIs in the existing protocol. There are no changes to these extensions but they will now satisfy the conformance to the `(baseName)ClientProtocolV2` by providing a *default* implementation unless a conforming type provides one itself.
**AWS(baseName)Client**: an existing type that conforms to the `(baseName)ClientProtocol`, adding Swift Concurrency based implementations that call into the Swift Concurrency based APIs of `smoke-http`. Because these APIs are now implemented within this type, they will *override the default* implementations in the extension of the protocol.
**Mock(baseName)ClientV2** and **Throwing(baseName)ClientV2**: Mock implementations that conform to the `(baseName)ClientProtocolV2` protocol. These implementations just provide the ability to mock the Swift Concurrency (Async/Await) based APIs and therefore do not require passing an `EventLoop` to their initializer.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.