### PR TITLE
Add another reserved word: operator

### DIFF
--- a/Sources/ServiceModelEntities/String+nameConversions.swift
+++ b/Sources/ServiceModelEntities/String+nameConversions.swift
@@ -18,7 +18,8 @@
 import Foundation
 
 private let reservedWords: Set<String> = ["in", "protocol", "return", "default", "public", "self",
-                                          "static", "private", "internal", "do", "is", "as", "true", "false", "import"]
+                                          "static", "private", "internal", "do", "is", "as", "true", "false", "import",
+                                          "operator"]
 
 public extension String {
     /**


### PR DESCRIPTION
*Issue #, if available:*
Model with "operator" enum case does not compile. "operator" keyword needs to be escaped.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
