### PR TITLE
Use type's default for default stub map key

### DIFF
--- a/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+createStructureStubVariable.swift
+++ b/Sources/ServiceModelGenerate/ServiceModelCodeGenerator+createStructureStubVariable.swift
@@ -157,7 +157,9 @@ internal extension ServiceModelCodeGenerator {
         return fieldValue
     }
     
-    private func getMapFieldValue(lengthConstraint: LengthRangeConstraint<Int>, valueType: String,
+    private func getMapFieldValue(lengthConstraint: LengthRangeConstraint<Int>,
+                                  keyType: String,
+                                  valueType: String,
                                   fileBuilder: FileBuilder) -> String {
         let fieldValue: String
         
@@ -173,8 +175,14 @@ internal extension ServiceModelCodeGenerator {
             // create a map that satifies at least the minimum constraint
             var mapConstructor: [String] = []
             let defaultValue = getDefaultValue(type: valueType, fileBuilder: fileBuilder)
-            for index in 0..<requiredSize {
-                mapConstructor.append("\"Entry_\(index)\": \(defaultValue)")
+
+            if requiredSize == 1 {
+                let defaultKeyValue = getDefaultValue(type: keyType, fileBuilder: fileBuilder)
+                mapConstructor.append("\(defaultKeyValue): \(defaultValue)")
+            } else {
+                for index in 0..<requiredSize {
+                    mapConstructor.append("\"Entry_\(index)\": \(defaultValue)")
+                }
             }
             
             fieldValue = "[\(mapConstructor.joined(separator: ", "))]"
@@ -211,9 +219,10 @@ internal extension ServiceModelCodeGenerator {
             fieldValue = overrideDefaultValue ?? "\"\(exampleDateString)\""
         case .list(type: let listType, lengthConstraint: let lengthConstraint):
             fieldValue = getListFieldValue(lengthConstraint: lengthConstraint, listType: listType, fileBuilder: fileBuilder)
-        case .map(keyType: _, valueType: let valueType,
+        case .map(keyType: let keyType,
+                  valueType: let valueType,
                   lengthConstraint: let lengthConstraint):
-            fieldValue = getMapFieldValue(lengthConstraint: lengthConstraint, valueType: valueType, fileBuilder: fileBuilder)
+            fieldValue = getMapFieldValue(lengthConstraint: lengthConstraint, keyType: keyType, valueType: valueType, fileBuilder: fileBuilder)
         }
         
         return fieldValue


### PR DESCRIPTION
Some models use specific non-primitive type
for a map key, such as an enum. Not resolving
to that results in a compilation failure.

*Issue #, if available:*

The particular issue is in smoke-aws. When building AppConfig model default instance ends up with:

```
     static let __default: AppConfigModel.CreateExtensionRequest = {
         let defaultInstance = AppConfigModel.CreateExtensionRequest(
            actions: ["Entry_0": [Action.__default]],
             description: nil,
             latestVersionNumber: nil,
             name: "0",
```

After this change the default instance will be:

```
     static let __default: AppConfigModel.CreateExtensionRequest = {
         let defaultInstance = AppConfigModel.CreateExtensionRequest(
            actions: [ActionPoint.__default: [Action.__default]],
             description: nil,
             latestVersionNumber: nil,
             name: "0",
```

*Description of changes:*

When building a default instance, resolve key to a specific default value for that type if possible.

Running smoke-aws-generate with this build results in the following changes:

```diff
--- a/Sources/AppConfigModel/AppConfigModelDefaultInstances.swift
+++ b/Sources/AppConfigModel/AppConfigModelDefaultInstances.swift
@@ -292,7 +292,7 @@ public extension CreateExtensionRequest {
      */
     static let __default: AppConfigModel.CreateExtensionRequest = {
         let defaultInstance = AppConfigModel.CreateExtensionRequest(
-            actions: ["Entry_0": [Action.__default]],
+            actions: [ActionPoint.__default: [Action.__default]],
             description: nil,
             latestVersionNumber: nil,
             name: "0",
diff --git a/Sources/CloudformationModel/CloudformationModelDefaultInstances.swift b/Sources/CloudformationM
odel/CloudformationModelDefaultInstances.swift
index 3deb8b9..c9baec4 100644
--- a/Sources/CloudformationModel/CloudformationModelDefaultInstances.swift
+++ b/Sources/CloudformationModel/CloudformationModelDefaultInstances.swift
@@ -2830,7 +2830,7 @@ public extension ResourceToImport {
     static let __default: CloudformationModel.ResourceToImport = {
         let defaultInstance = CloudformationModel.ResourceToImport(
             logicalResourceId: "value",
-            resourceIdentifier: ["Entry_0": "0"],
+            resourceIdentifier: ["0": "0"],
             resourceType: "0")

         return defaultInstance
diff --git a/Sources/DynamoDBModel/DynamoDBModelDefaultInstances.swift b/Sources/DynamoDBModel/DynamoDBModelDefaultInstances.swift
index 31cfced..9bf6dfc 100644
--- a/Sources/DynamoDBModel/DynamoDBModelDefaultInstances.swift
+++ b/Sources/DynamoDBModel/DynamoDBModelDefaultInstances.swift
@@ -280,7 +280,7 @@ public extension BatchGetItemInput {
      */
     static let __default: DynamoDBModel.BatchGetItemInput = {
         let defaultInstance = DynamoDBModel.BatchGetItemInput(
-            requestItems: ["Entry_0": KeysAndAttributes.__default],
+            requestItems: ["012": KeysAndAttributes.__default],
             returnConsumedCapacity: nil)

         return defaultInstance
@@ -350,7 +350,7 @@ public extension BatchWriteItemInput {
      */
     static let __default: DynamoDBModel.BatchWriteItemInput = {
         let defaultInstance = DynamoDBModel.BatchWriteItemInput(
-            requestItems: ["Entry_0": [WriteRequest.__default]],
+            requestItems: ["012": [WriteRequest.__default]],
             returnConsumedCapacity: nil,
             returnItemCollectionMetrics: nil)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
