### PR TITLE
Update SwaggerParser repository location because original is 404

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "SwaggerParser",
-        "repositoryURL": "https://github.com/tachyonics/SwaggerParser.git",
+        "repositoryURL": "https://github.com/knovichikhin/SwaggerParser.git",
         "state": {
           "branch": null,
           "revision": "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
             targets: ["SwaggerServiceModel"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tachyonics/SwaggerParser.git", from: "0.6.4"), 
+        .package(url: "https://github.com/knovichikhin/SwaggerParser.git", from: "0.6.4"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "0.5.0")
     ],
     targets: [


### PR DESCRIPTION
*Issue #, if available:*
Update SwaggerParser repository location because original is 404

*Description of changes:*
Updated to use forked SwaggerParser

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
